### PR TITLE
Skylark library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,8 @@
-licenses(["notice"])
+licenses(["notice"])  # Apache 2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//:skylark_library.bzl", "skylark_library")
 
 exports_files([
     "LICENSE",
@@ -12,5 +16,24 @@ filegroup(
         "//lib:test_deps",
     ] + glob(["*.bzl"]),
     testonly = True,
-    visibility = ["//visibility:public"],
+)
+
+skylark_library(
+    name = "lib",
+    srcs = ["lib.bzl"],
+    deps = [
+        "//lib:collections",
+        "//lib:dicts",
+        "//lib:paths",
+        "//lib:selects",
+        "//lib:sets",
+        "//lib:shell",
+        "//lib:structs",
+        "//lib:unittest",
+    ],
+)
+
+skylark_library(
+    name = "skylark_library",
+    srcs = ["skylark_library.bzl"],
 )

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Dmitry Lomov <dslomov@google.com>
 Jon Brandvein <brandjon@google.com>
 Laurent Le Brun <laurentlb@google.com>
 Tony Allevato <allevato@google.com>
+Nathan Herring <nherring@google.com>

--- a/README.md
+++ b/README.md
@@ -73,6 +73,6 @@ Steps to add a module to Skylib:
 
 ## `skylark_library`
 
-The `skylark_library.bzl` rule allows aggregation of Skylark
-rules for use in Python-interpreter-based unit tests and documentation
-generation.
+The `skylark_library.bzl` rule can be used to aggregate a set of
+Skylark files and its dependencies for use in test targets and
+documentation generation.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,9 @@ Steps to add a module to Skylib:
    ```
 
 1. Add unit tests for your module in the `tests` directory.
+
+## `skylark_library`
+
+The `skylark_library.bzl` rule allows aggregation of Skylark
+rules for use in Python-interpreter-based unit tests and documentation
+generation.

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,6 +1,6 @@
 licenses(["notice"])
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//:__pkg__"])
 
 load("//:skylark_library.bzl", "skylark_library")
 

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,8 +1,53 @@
 licenses(["notice"])
 
+package(default_visibility = ["//visibility:public"])
+
+load("//:skylark_library.bzl", "skylark_library")
+
 filegroup(
     name = "test_deps",
     srcs = ["BUILD"] + glob(["*.bzl"]),
     testonly = True,
     visibility = ["//visibility:public"],
+)
+
+skylark_library(
+    name = "collections",
+    srcs = ["collections.bzl"],
+)
+
+skylark_library(
+    name = "dicts",
+    srcs = ["dicts.bzl"],
+)
+
+skylark_library(
+    name = "paths",
+    srcs = ["paths.bzl"],
+)
+
+skylark_library(
+    name = "selects",
+    srcs = ["selects.bzl"],
+)
+
+skylark_library(
+    name = "sets",
+    srcs = ["sets.bzl"],
+)
+
+skylark_library(
+    name = "shell",
+    srcs = ["shell.bzl"],
+)
+
+skylark_library(
+    name = "structs",
+    srcs = ["structs.bzl"],
+)
+
+skylark_library(
+    name = "unittest",
+    srcs = ["unittest.bzl"],
+    deps = [":sets"],
 )

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -1,0 +1,103 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing a library rule for aggregating rules files."""
+
+SkylarkLibraryInfo = provider()
+
+def _skylark_library_impl(ctx):
+  all_files = depset(ctx.files.srcs, order="postorder")
+  for dep in ctx.attr.deps:
+    all_files += dep.files
+  return [
+      # All dependent files should be listed in both `files` and in `runfiles`;
+      # this ensures that a `library()` can be referenced as `data` from a
+      # separate program, or from `tools` of a genrule().
+      DefaultInfo(
+          files = all_files,
+          runfiles = ctx.runfiles(files=list(all_files)),
+      ),
+
+      # We also define our own provider struct, for aggregation and testing.
+      SkylarkLibraryInfo(
+          srcs = ctx.files.srcs,
+          transitive_srcs = all_files,
+      ),
+  ]
+
+skylark_library = rule(
+    implementation = _skylark_library_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files=[".bzl"],
+        ),
+        "deps": attr.label_list(
+            providers=[
+                [SkylarkLibraryInfo],
+                ["files"],
+            ],
+        )
+    }
+)
+"""Creates a logical collection of Skylark .bzl files.
+
+Args:
+  srcs: List of `.bzl` files that are processed to create this target.
+  deps: List of other `library` targets that are required by the Skylark files
+    listed in `srcs`.
+
+Example:
+  Suppose your project has the following structure:
+
+  ```
+  [workspace]/
+      WORKSPACE
+      BUILD
+      checkstyle/
+          BUILD
+          checkstyle.bzl
+      lua/
+          BUILD
+          lua.bzl
+          luarocks.bzl
+  ```
+
+  In this case, you can have `skylark_library` targets in `checkstyle/BUILD` and
+  `lua/BUILD`:
+
+  `checkstyle/BUILD`:
+
+  ```python
+  load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+
+  skylark_library(
+      name = "checkstyle-rules",
+      srcs = ["checkstyle.bzl"],
+  )
+  ```
+
+  `lua/BUILD`:
+
+  ```python
+  load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+
+  skylark_library(
+      name = "lua-rules",
+      srcs = [
+          "lua.bzl",
+          "luarocks.bzl",
+      ],
+  )
+  ```
+"""

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -50,9 +50,9 @@ skylark_library = rule(
             allow_files=[".bzl"],
         ),
         "deps": attr.label_list(
+            allow_files=[".bzl"],
             providers=[
                 [SkylarkLibraryInfo],
-                ["files"],
             ],
         )
     }

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -14,7 +14,14 @@
 
 """Skylib module containing a library rule for aggregating rules files."""
 
-SkylarkLibraryInfo = provider()
+SkylarkLibraryInfo = provider(
+    'Information on contained Skylark rules.',
+    fields={
+      'srcs': 'Top level rules files.',
+      'transitive_srcs': 'Transitive closure of rules files required for ' +
+          'interpretation of the srcs',
+    },
+)
 
 def _skylark_library_impl(ctx):
   all_files = depset(ctx.files.srcs, order="postorder")
@@ -22,17 +29,17 @@ def _skylark_library_impl(ctx):
     all_files += dep.files
   return [
       # All dependent files should be listed in both `files` and in `runfiles`;
-      # this ensures that a `library()` can be referenced as `data` from a
-      # separate program, or from `tools` of a genrule().
+      # this ensures that a `skylark_library` can be referenced as `data` from
+      # a separate program, or from `tools` of a genrule().
       DefaultInfo(
-          files = all_files,
-          runfiles = ctx.runfiles(files=list(all_files)),
+          files=all_files,
+          runfiles=ctx.runfiles(files=list(all_files)),
       ),
 
       # We also define our own provider struct, for aggregation and testing.
       SkylarkLibraryInfo(
-          srcs = ctx.files.srcs,
-          transitive_srcs = all_files,
+          srcs=ctx.files.srcs,
+          transitive_srcs=all_files,
       ),
   ]
 
@@ -54,8 +61,8 @@ skylark_library = rule(
 
 Args:
   srcs: List of `.bzl` files that are processed to create this target.
-  deps: List of other `library` targets that are required by the Skylark files
-    listed in `srcs`.
+  deps: List of other `skylark_library` targets that are required by the
+    Skylark files listed in `srcs`.
 
 Example:
   Suppose your project has the following structure:

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -44,8 +44,8 @@ def _skylark_library_impl(ctx):
   ]
 
 skylark_library = rule(
-    implementation = _skylark_library_impl,
-    attrs = {
+    implementation=_skylark_library_impl,
+    attrs={
         "srcs": attr.label_list(
             allow_files=[".bzl"],
         ),


### PR DESCRIPTION
Adding a `skylark_library` target for rules files suitable for use in Python-interpretation-based unit tests, as well as a parent target for [Skydoc doc generation](https://skydoc.bazel.build/)'s `skydoc_library`.