### PR TITLE
versions.bzl: skip check if native.bazel_version is None

### DIFF
--- a/lib/versions.bzl
+++ b/lib/versions.bzl
@@ -97,6 +97,7 @@ def _check_bazel_version(minimum_bazel_version, maximum_bazel_version=None, baze
     elif not native.bazel_version:
       print("\nCurrent Bazel is not a release version, cannot check for compatibility.")
       print("Make sure that you are running at least Bazel %s.\n" % minimum_bazel_version)
+      return
     else:
       bazel_version = native.bazel_version
 


### PR DESCRIPTION
_check_bazel_version prints a warning in this case, but then attempts
to parse and check None. It should return early.