### PR TITLE
add buildkite to bazel's new ci

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,17 @@
+---
+platforms:
+  ubuntu1404:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  ubuntu1604:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  macos:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Skylib
 
 [![Build Status](https://travis-ci.org/bazelbuild/bazel-skylib.svg?branch=master)](https://travis-ci.org/bazelbuild/bazel-skylib)
+[![Build status](https://badge.buildkite.com/921dc61e2d3a350ec40efb291914360c0bfa9b6196fa357420.svg)](https://buildkite.com/bazel/bazel-skylib-postsubmit)
 
 Skylib is a standard library that provides functions useful for manipulating
 collections, file paths, and other features that are useful when writing custom


### PR DESCRIPTION
we'll run skylib as a postsubmit project and
before every release to ensure we don't break
it.