### PR TITLE
Travis improvements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,43 +9,33 @@ matrix:
     - os: linux
       dist: trusty
       sudo: false
-      env: BAZEL_VERSION=0.10.1
+      env: BAZEL=RELEASE
     - os: linux
       dist: trusty
       sudo: false
-      env: BAZEL_VERSION=HEAD
+      env: BAZEL=HEAD
+    - os: linux
+      dist: trusty
+      sudo: false
+      env: BUILDIFER=RELEASE
 
     # -----------------------------------------------------------------
     # macOS hosted tests
 
     - os: osx
       osx_image: xcode9.2
-      env: BAZEL_VERSION=0.10.1
+      env: BAZEL=RELEASE
     - os: osx
       osx_image: xcode9.2
-      env: BAZEL_VERSION=HEAD
+      env: BAZEL=HEAD
+    # No need for a BUILDIFER run on mac, the results will be the same.
+    # And linux boxes test faster on travis, so just use the one.
 
 before_install:
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      OS=darwin
-    else
-      OS=linux
-    fi
-    # macOS and trusty images have jdk8
-    if [[ "${BAZEL_VERSION}" == "HEAD" ]]; then
-      URL="https://ci.bazel.build/view/Bazel%20bootstrap%20and%20maintenance/job/bazel/job/nightly/lastSuccessfulBuild/artifact/node=${OS}-x86_64/bazel--without-jdk-installer-${OS}-x86_64.sh"
-    else
-      URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-without-jdk-installer-${OS}-x86_64.sh"
-    fi
-    wget -O install.sh "${URL}"
-    chmod +x install.sh
-    ./install.sh --user
-    rm -f install.sh
-    bazel version
+  - ./.travis_install.sh
 
 script:
-  - bazel --bazelrc=/dev/null test --show_progress_rate_limit=30.0 //...
+  - ./.travis_build.sh
 
 notifications:
   email: false

--- a/.travis_build.sh
+++ b/.travis_build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eu
+
+# -------------------------------------------------------------------------------------------------
+# Asked to do a bazel build.
+if [[ -n "${BAZEL:-}" ]]; then
+  bazel --bazelrc=/dev/null test --show_progress_rate_limit=30.0 //...
+fi
+
+# -------------------------------------------------------------------------------------------------
+# Asked to do a buildifier run.
+if [[ -n "${BUILDIFER:-}" ]]; then
+  # bazelbuild/buildtools/issues/220 - diff doesn't include the file that needs updating
+  # bazelbuild/buildtools/issues/221 - the exist status is always zero.
+  if [[ -n "$(find . -name BUILD -print | xargs buildifier -v -d)" ]]; then
+    echo "ERROR: BUILD file formatting issue(s)"
+    find . -name BUILD -print -exec buildifier -v -d {} \;
+    exit 1
+  fi
+fi

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -eux
+
+if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+  OS=darwin
+else
+  OS=linux
+fi
+
+# -------------------------------------------------------------------------------------------------
+# Helper to use the github redirect to find the latest release.
+function github_latest_release_tag() {
+  local PROJECT=$1
+  curl \
+      -s \
+      -o /dev/null \
+      --write-out '%{redirect_url}' \
+      "https://github.com/${PROJECT}/releases/latest" \
+  | sed -e 's,https://.*/releases/tag/\(.*\),\1,'
+}
+
+
+# -------------------------------------------------------------------------------------------------
+# Helper to install bazel.
+function install_bazel() {
+  local VERSION="${1}"
+
+  if [[ "${VERSION}" == "RELEASE" ]]; then
+    VERSION="$(github_latest_release_tag bazelbuild/bazel)"
+  fi
+
+  # macOS and trusty images have jdk8
+  if [[ "${VERSION}" == "HEAD" ]]; then
+    URL="https://ci.bazel.build/view/Bazel%20bootstrap%20and%20maintenance/job/bazel/job/nightly/lastSuccessfulBuild/artifact/node=${OS}-x86_64/bazel--without-jdk-installer-${OS}-x86_64.sh"
+  else
+    URL="https://github.com/bazelbuild/bazel/releases/download/${VERSION}/bazel-${VERSION}-without-jdk-installer-${OS}-x86_64.sh"
+  fi
+
+  wget -O install.sh "${URL}"
+  chmod +x install.sh
+  ./install.sh --user
+  rm -f install.sh
+  bazel version
+}
+
+# -------------------------------------------------------------------------------------------------
+# Helper to install buildifier.
+function install_buildifier() {
+  local VERSION="${1}"
+
+  if [[ "${VERSION}" == "RELEASE" ]]; then
+    VERSION="$(github_latest_release_tag bazelbuild/buildtools)"
+  fi
+
+  if [[ "${VERSION}" == "HEAD" ]]; then
+    echo "buildifer head is not supported"
+    exit 1
+  fi
+
+  if [[ "${OS}" == "darwin" ]]; then
+    URL="https://github.com/bazelbuild/buildtools/releases/download/${VERSION}/buildifier.osx"
+  else
+    URL="https://github.com/bazelbuild/buildtools/releases/download/${VERSION}/buildifier"
+  fi
+
+  wget -O "${HOME}/bin/buildifier" "${URL}"
+  chmod +x "${HOME}/bin/buildifier"
+  buildifier --version
+}
+
+# -------------------------------------------------------------------------------------------------
+# Install what is requested.
+[[ -z "${BAZEL:-}" ]] || install_bazel "${BAZEL}"
+[[ -z "${BUILDIFER:-}" ]] || install_buildifier "${BUILDIFER}"


### PR DESCRIPTION
- Move install into a stand alone script to expand it.
  - Support installing the latest bazel release.
- Move the script step into a stand along script to expand it.
  - Support doing a build or running buildifier.
- Update the config to:
  - Use the latest bazel release and head for tests (won't have
    to update the config with each bazel release).
  - Add a buildifer test to ensure the files are good.