### PR TITLE
Test HEAD bazel on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: false
-      env: BAZEL=RELEASE
+      env: BAZEL=HEAD
     - os: linux
       dist: trusty
       sudo: false
@@ -20,7 +20,7 @@ matrix:
 
     - os: osx
       osx_image: xcode9.2
-      env: BAZEL=RELEASE
+      env: BAZEL=HEAD
     # No need for a BUILDIFER run on mac, the results will be the same.
     # And linux boxes test faster on travis, so just use the one.
 


### PR DESCRIPTION
- Add support for fetch HEAD bazel from their new setup.
- Switch travis to building with HEAD since bazel's ci is using the last release.