### PR TITLE
Add strings lib with strip_margin utility

### DIFF
--- a/lib.bzl
+++ b/lib.bzl
@@ -22,6 +22,7 @@ load("//lib:paths.bzl", _paths="paths")
 load("//lib:selects.bzl", _selects="selects")
 load("//lib:sets.bzl", _sets="sets")
 load("//lib:shell.bzl", _shell="shell")
+load("//lib:strings.bzl", _strings="strings")
 load("//lib:structs.bzl", _structs="structs")
 load("//lib:versions.bzl", _versions="versions")
 
@@ -38,6 +39,7 @@ paths = _paths
 selects = _selects
 sets = _sets
 shell = _shell
+strings = _strings
 structs = _structs
 versions = _versions
 

--- a/lib/strings.bzl
+++ b/lib/strings.bzl
@@ -1,0 +1,48 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing functions that operate on strings."""
+
+
+def _strip_margin(str, delim = "|"):
+    """Strips a leading margin from each line in a multiline string.
+
+    For each line in `str`:
+      Strip a leading prefix consisting of spaces followed by `delim` from the line.
+
+    This is extremely similar to Scala's .stripMargin
+
+    Args:
+      str: An input string.
+      delim: The margin delimiter, defaulting to `|`.
+
+    Returns:
+      The input string with a margin prefix removed from each line.
+    """
+    return "\n".join([
+        _strip_margin_line(line, delim)
+        for line in str.splitlines()
+    ])
+
+def _strip_margin_line(line, delim):
+    trimmed = line.lstrip(" ")
+    pos = trimmed.find(delim, end = 1)
+    if pos == 0:
+        return trimmed[1:]
+    else:
+        return line
+
+strings = struct(
+    strip_margin = _strip_margin
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -7,6 +7,7 @@ load(":sets_tests.bzl", "sets_test_suite")
 load(":new_sets_tests.bzl", "new_sets_test_suite")
 load(":shell_tests.bzl", "shell_test_suite")
 load(":structs_tests.bzl", "structs_test_suite")
+load(":strings_tests.bzl", "strings_test_suite")
 load(":versions_tests.bzl", "versions_test_suite")
 
 licenses(["notice"])
@@ -28,5 +29,7 @@ new_sets_test_suite()
 shell_test_suite()
 
 structs_test_suite()
+
+strings_test_suite()
 
 versions_test_suite()

--- a/tests/strings_tests.bzl
+++ b/tests/strings_tests.bzl
@@ -1,0 +1,90 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for structs.bzl."""
+
+load("//:lib.bzl", "strings", "asserts", "unittest")
+
+
+def _strip_margin_test(ctx):
+  """Unit tests for dicts.add."""
+  env = unittest.begin(ctx)
+
+  io_pairs = []
+
+  input = """"""
+  output = """"""
+  io_pairs.append((input, output, None))
+
+  input = """|"""
+  output = """"""
+  io_pairs.append((input, output, None))
+
+  input = """|"""
+  output = """|"""
+  io_pairs.append((input, output, ':'))
+
+  input = """   :a
+   :b
+:c"""
+  output = """a
+b
+c"""
+  io_pairs.append((input, output, ':'))
+
+  input = """
+    |hello
+    |world
+    |"""
+  output = """
+hello
+world
+"""
+  io_pairs.append((input, output, None))
+
+  input = """
+    |TIME_MS=`awk -F '=' '$1 == "build_time" {{ print $2 }}' $STATSFILE`
+    |
+    |if [ ! -z "$TIME_MS" ]; then
+    |  TIME_S=`awk "BEGIN {{ printf \\"%.3f\\n\\", $TIME_MS / 1000 }}"`
+    |  LOC_PER_S=`awk "BEGIN {{ printf \\"%.2f\\n\\", $N_LINES / $TIME_S }}"`
+    |fi
+    |"""
+  output = """
+TIME_MS=`awk -F '=' '$1 == "build_time" {{ print $2 }}' $STATSFILE`
+
+if [ ! -z "$TIME_MS" ]; then
+  TIME_S=`awk "BEGIN {{ printf \\"%.3f\\n\\", $TIME_MS / 1000 }}"`
+  LOC_PER_S=`awk "BEGIN {{ printf \\"%.2f\\n\\", $N_LINES / $TIME_S }}"`
+fi
+"""
+  io_pairs.append((input, output, None))
+
+  for i, o, d in io_pairs:
+      if d == None:
+          asserts.equals(env, o, strings.strip_margin(i))
+      else:
+          asserts.equals(env, o, strings.strip_margin(i, d))
+
+  unittest.end(env)
+
+strip_margin_test = unittest.make(_strip_margin_test)
+
+
+def strings_test_suite():
+  """Creates the test targets and test suite for strings.bzl tests."""
+  unittest.suite(
+      "strings_tests",
+      strip_margin_test,
+  )


### PR DESCRIPTION
The primary use case for the new utility is to be able to write inline multiline strings with indentation that matches the rest of the file.

Example from some rules I've been working on:
```
def _some_rule_impl(ctx):
    # ...
    ctx.actions.run_shell(
        inputs = inputs,
        outputs = [output_jar],
        command = strip_margin(
            """
            |set -eo pipefail
            |
            |mkdir tmp/classes
            |
            |{java} \\
            |  -cp {compiler_classpath} \\
            |  scala.tools.nsc.Main \\
            |  -cp {compile_classpath} \\
            |  -d tmp/classes \\
            |  {srcs}
            |
            |{jar_creator} {output_jar} tmp/classes 2> /dev/null
            |""".format(
                jar = jar.path,
                java = java.path,
                jar_creator = jar_creator.path,
                compiler_classpath = compiler_classpath_str,
                compile_classpath = compile_classpath_str,
                srcs = srcs_string,
                src_jars = src_jars_string,
                output_jar = output_jar.path,
            ),
        ),
    )
```