### PR TITLE
Add type checking functions.

### DIFF
--- a/lib.bzl
+++ b/lib.bzl
@@ -23,6 +23,7 @@ load("//lib:selects.bzl", _selects="selects")
 load("//lib:sets.bzl", _sets="sets")
 load("//lib:shell.bzl", _shell="shell")
 load("//lib:structs.bzl", _structs="structs")
+load("//lib:types.bzl", _types="types")
 load("//lib:versions.bzl", _versions="versions")
 
 # The unittest module is treated differently to give more convenient names to
@@ -39,6 +40,7 @@ selects = _selects
 sets = _sets
 shell = _shell
 structs = _structs
+types = _types
 versions = _versions
 
 asserts = _asserts

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -57,6 +57,11 @@ skylark_library(
 )
 
 skylark_library(
+    name = "types",
+    srcs = ["types.bzl"],
+)
+
+skylark_library(
     name = "unittest",
     srcs = ["unittest.bzl"],
     deps = [":sets"],

--- a/lib/types.bzl
+++ b/lib/types.bzl
@@ -1,0 +1,135 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Skylib module containing functions checking types."""
+
+
+# create instance singletons to avoid unnecessary allocations
+_a_bool = True
+_a_dict = {}
+_a_list = []
+_a_string = ""
+_a_tuple = ()
+_an_int = 1
+
+
+def _a_function():
+  pass
+
+
+def _is_list(v):
+    """Returns True if v is an instance of a list.
+
+  Args:
+    v: The value whose type should be checked.
+
+  Returns:
+    True if v is an instance of a list, False otherwise.
+  """
+    return type(v) == type(_a_list)
+
+
+def _is_string(v):
+    """Returns True if v is an instance of a string.
+
+  Args:
+    v: The value whose type should be checked.
+
+  Returns:
+    True if v is an instance of a string, False otherwise.
+  """
+    return type(v) == type(_a_string)
+
+
+def _is_bool(v):
+    """Returns True if v is an instance of a bool.
+
+  Args:
+    v: The value whose type should be checked.
+
+  Returns:
+    True if v is an instance of a bool, False otherwise.
+  """
+    return type(v) == type(_a_bool)
+
+
+def _is_none(v):
+    """Returns True if v has the type of None.
+
+  Args:
+    v: The value whose type should be checked.
+
+  Returns:
+    True if v is None, False otherwise.
+  """
+    return type(v) == type(None)
+
+
+def _is_int(v):
+    """Returns True if v is an instance of a signed integer.
+
+  Args:
+    v: The value whose type should be checked.
+
+  Returns:
+    True if v is an instance of a signed integer, False otherwise.
+  """
+    return type(v) == type(_an_int)
+
+
+def _is_tuple(v):
+    """Returns True if v is an instance of a tuple.
+
+  Args:
+    v: The value whose type should be checked.
+
+  Returns:
+    True if v is an instance of a tuple, False otherwise.
+  """
+    return type(v) == type(_a_tuple)
+
+
+def _is_dict(v):
+    """Returns True if v is an instance of a dict.
+
+  Args:
+    v: The value whose type should be checked.
+
+  Returns:
+    True if v is an instance of a dict, False otherwise.
+  """
+    return type(v) == type(_a_dict)
+
+
+def _is_function(v):
+    """Returns True if v is an instance of a function.
+
+  Args:
+    v: The value whose type should be checked.
+
+  Returns:
+    True if v is an instance of a function, False otherwise.
+  """
+    return type(v) == type(_a_function)
+
+
+types = struct(
+    is_list=_is_list,
+    is_string=_is_string,
+    is_bool=_is_bool,
+    is_none=_is_none,
+    is_int=_is_int,
+    is_tuple=_is_tuple,
+    is_dict=_is_dict,
+    is_function=_is_function,
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -7,6 +7,7 @@ load(":sets_tests.bzl", "sets_test_suite")
 load(":new_sets_tests.bzl", "new_sets_test_suite")
 load(":shell_tests.bzl", "shell_test_suite")
 load(":structs_tests.bzl", "structs_test_suite")
+load(":types_tests.bzl", "types_test_suite")
 load(":versions_tests.bzl", "versions_test_suite")
 
 licenses(["notice"])
@@ -28,5 +29,7 @@ new_sets_test_suite()
 shell_test_suite()
 
 structs_test_suite()
+
+types_test_suite()
 
 versions_test_suite()

--- a/tests/types_tests.bzl
+++ b/tests/types_tests.bzl
@@ -1,0 +1,215 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for types.bzl."""
+
+load("//:lib.bzl", "types", "asserts", "unittest")
+
+
+def _a_function():
+    """A dummy function for testing."""
+    pass
+
+
+def _is_string_test(ctx):
+    """Unit tests for types.is_string."""
+
+    env = unittest.begin(ctx)
+
+    asserts.true(env, types.is_string(""))
+    asserts.true(env, types.is_string("string"))
+
+    asserts.false(env, types.is_string(4))
+    asserts.false(env, types.is_string([1]))
+    asserts.false(env, types.is_string({}))
+    asserts.false(env, types.is_string(()))
+    asserts.false(env, types.is_string(True))
+    asserts.false(env, types.is_string(None))
+    asserts.false(env, types.is_string(_a_function))
+
+    unittest.end(env)
+
+
+is_string_test = unittest.make(_is_string_test)
+
+
+def _is_bool_test(ctx):
+    """Unit tests for types.is_bool."""
+
+    env = unittest.begin(ctx)
+
+    asserts.true(env, types.is_bool(True))
+    asserts.true(env, types.is_bool(False))
+
+    asserts.false(env, types.is_bool(4))
+    asserts.false(env, types.is_bool([1]))
+    asserts.false(env, types.is_bool({}))
+    asserts.false(env, types.is_bool(()))
+    asserts.false(env, types.is_bool(""))
+    asserts.false(env, types.is_bool(None))
+    asserts.false(env, types.is_bool(_a_function))
+
+    unittest.end(env)
+
+
+is_bool_test = unittest.make(_is_bool_test)
+
+
+def _is_list_test(ctx):
+    """Unit tests for types.is_list."""
+
+    env = unittest.begin(ctx)
+
+    asserts.true(env, types.is_list([]))
+    asserts.true(env, types.is_list([1]))
+
+    asserts.false(env, types.is_list(4))
+    asserts.false(env, types.is_list("s"))
+    asserts.false(env, types.is_list({}))
+    asserts.false(env, types.is_list(()))
+    asserts.false(env, types.is_list(True))
+    asserts.false(env, types.is_list(None))
+    asserts.false(env, types.is_list(_a_function))
+
+    unittest.end(env)
+
+
+is_list_test = unittest.make(_is_list_test)
+
+
+def _is_none_test(ctx):
+    """Unit tests for types.is_none."""
+
+    env = unittest.begin(ctx)
+
+    asserts.true(env, types.is_none(None))
+
+    asserts.false(env, types.is_none(4))
+    asserts.false(env, types.is_none("s"))
+    asserts.false(env, types.is_none({}))
+    asserts.false(env, types.is_none(()))
+    asserts.false(env, types.is_none(True))
+    asserts.false(env, types.is_none([]))
+    asserts.false(env, types.is_none([1]))
+    asserts.false(env, types.is_none(_a_function))
+
+    unittest.end(env)
+
+
+is_none_test = unittest.make(_is_none_test)
+
+
+def _is_int_test(ctx):
+    """Unit tests for types.is_int."""
+
+    env = unittest.begin(ctx)
+
+    asserts.true(env, types.is_int(1))
+    asserts.true(env, types.is_int(-1))
+
+    asserts.false(env, types.is_int("s"))
+    asserts.false(env, types.is_int({}))
+    asserts.false(env, types.is_int(()))
+    asserts.false(env, types.is_int(True))
+    asserts.false(env, types.is_int([]))
+    asserts.false(env, types.is_int([1]))
+    asserts.false(env, types.is_int(None))
+    asserts.false(env, types.is_int(_a_function))
+
+    unittest.end(env)
+
+
+is_int_test = unittest.make(_is_int_test)
+
+
+def _is_tuple_test(ctx):
+    """Unit tests for types.is_tuple."""
+
+    env = unittest.begin(ctx)
+
+    asserts.true(env, types.is_tuple(()))
+    asserts.true(env, types.is_tuple((1, )))
+
+    asserts.false(env, types.is_tuple(1))
+    asserts.false(env, types.is_tuple("s"))
+    asserts.false(env, types.is_tuple({}))
+    asserts.false(env, types.is_tuple(True))
+    asserts.false(env, types.is_tuple([]))
+    asserts.false(env, types.is_tuple([1]))
+    asserts.false(env, types.is_tuple(None))
+    asserts.false(env, types.is_tuple(_a_function))
+
+    unittest.end(env)
+
+
+is_tuple_test = unittest.make(_is_tuple_test)
+
+
+def _is_dict_test(ctx):
+    """Unit tests for types.is_dict."""
+
+    env = unittest.begin(ctx)
+
+    asserts.true(env, types.is_dict({}))
+    asserts.true(env, types.is_dict({'key': 'value'}))
+
+    asserts.false(env, types.is_dict(1))
+    asserts.false(env, types.is_dict("s"))
+    asserts.false(env, types.is_dict(()))
+    asserts.false(env, types.is_dict(True))
+    asserts.false(env, types.is_dict([]))
+    asserts.false(env, types.is_dict([1]))
+    asserts.false(env, types.is_dict(None))
+    asserts.false(env, types.is_dict(_a_function))
+
+    unittest.end(env)
+
+
+is_dict_test = unittest.make(_is_dict_test)
+
+
+def _is_function_test(ctx):
+    """Unit tests for types.is_dict."""
+
+    env = unittest.begin(ctx)
+
+    asserts.true(env, types.is_function(_a_function))
+
+    asserts.false(env, types.is_function({}))
+    asserts.false(env, types.is_function(1))
+    asserts.false(env, types.is_function("s"))
+    asserts.false(env, types.is_function(()))
+    asserts.false(env, types.is_function(True))
+    asserts.false(env, types.is_function([]))
+    asserts.false(env, types.is_function([1]))
+    asserts.false(env, types.is_function(None))
+
+    unittest.end(env)
+
+
+is_function_test = unittest.make(_is_function_test)
+
+
+def types_test_suite():
+    """Creates the test targets and test suite for types.bzl tests."""
+    unittest.suite(
+        "types_tests",
+        is_list_test,
+        is_string_test,
+        is_bool_test,
+        is_none_test,
+        is_int_test,
+        is_tuple_test,
+        is_dict_test,
+        is_function_test,
+    )


### PR DESCRIPTION
Even though it's not great to use type checks, they are frequently useful for
checking input types of macros.

Because there is no standard way of checking types, at least 2 types of checks
are used:
- `type(foo) == type([])`
- `type(foo) == "list"`

The first option is not very readable and the second option seem to be relying
on an Bazel implementation detail. Encapsulating type checks into this library
enables consistent and easy to understand type checking without explicitly
relying on implementation details.

There are still more checks to add, but this change creates a scaffold.