### PR TITLE
All incompatible changes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+common --all_incompatible_changes

--- a/lib/new_sets.bzl
+++ b/lib/new_sets.bzl
@@ -34,6 +34,8 @@ def _make(elements = None):
       A set containing the passed in values.
     """
     elements = elements if elements else []
+    if type(elements) == "depset":
+        elements = elements.to_list()
     return struct(_values = {e: None for e in elements})
 
 def _copy(s):

--- a/lib/sets.bzl
+++ b/lib/sets.bzl
@@ -40,6 +40,16 @@ def _precondition_only_sets_or_lists(*args):
             fail("Expected arguments to be depset or list, but found type %s: %r" %
                  (t, a))
 
+def _convert_to_list(a):
+    """If the given value is a depset, convert it to a list. Otherwise do nothing.
+
+    Args:
+      *args: The value to be converted
+    """
+    if type(a) == "depset":
+        a = a.to_list()
+    return a
+
 def _is_equal(a, b):
     """Returns whether two sets are equal.
 
@@ -51,7 +61,7 @@ def _is_equal(a, b):
       True if `a` is equal to `b`, False otherwise.
     """
     _precondition_only_sets_or_lists(a, b)
-    return sorted(depset(a)) == sorted(depset(b))
+    return sorted(depset(a).to_list()) == sorted(depset(b).to_list())
 
 def _is_subset(a, b):
     """Returns whether `a` is a subset of `b`.
@@ -64,8 +74,8 @@ def _is_subset(a, b):
       True if `a` is a subset of `b`, False otherwise.
     """
     _precondition_only_sets_or_lists(a, b)
-    for e in a:
-        if e not in b:
+    for e in _convert_to_list(a):
+        if e not in _convert_to_list(b):
             return False
     return True
 
@@ -82,8 +92,8 @@ def _disjoint(a, b):
       True if `a` and `b` are disjoint, False otherwise.
     """
     _precondition_only_sets_or_lists(a, b)
-    for e in a:
-        if e in b:
+    for e in _convert_to_list(a):
+        if e in _convert_to_list(b):
             return False
     return True
 
@@ -98,14 +108,14 @@ def _intersection(a, b):
       A set containing the elements that are in both `a` and `b`.
     """
     _precondition_only_sets_or_lists(a, b)
-    return depset([e for e in a if e in b])
+    return depset([e for e in _convert_to_list(a) if e in _convert_to_list(b)])
 
 def _union(*args):
     """Returns the union of several sets.
 
     Args:
       *args: An arbitrary number of sets or lists.
-
+      *
     Returns:
       The set union of all sets or lists in `*args`.
     """
@@ -124,7 +134,7 @@ def _difference(a, b):
       A set containing the elements that are in `a` but not in `b`.
     """
     _precondition_only_sets_or_lists(a, b)
-    return depset([e for e in a if e not in b])
+    return depset([e for e in _convert_to_list(a) if e not in _convert_to_list(b)])
 
 sets = struct(
     difference = _difference,

--- a/lib/sets.bzl
+++ b/lib/sets.bzl
@@ -44,7 +44,7 @@ def _convert_to_list(a):
     """If the given value is a depset, convert it to a list. Otherwise do nothing.
 
     Args:
-      *args: The value to be converted
+      a: The value to be converted
     """
     if type(a) == "depset":
         a = a.to_list()
@@ -115,7 +115,6 @@ def _union(*args):
 
     Args:
       *args: An arbitrary number of sets or lists.
-      *
     Returns:
       The set union of all sets or lists in `*args`.
     """

--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -166,10 +166,10 @@ def _end(env):
         "EOF",
         "exit %d" % len(env.failures),
     ])
-    env.ctx.file_action(
+    env.ctx.actions.write(
         output = env.ctx.outputs.executable,
         content = cmd,
-        executable = True,
+        is_executable = True,
     )
 
 def _fail(env, msg):

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -32,9 +32,8 @@ def _skylark_library_impl(ctx):
         # a separate program, or from `tools` of a genrule().
         DefaultInfo(
             files = all_files,
-            runfiles = ctx.runfiles(files = list(all_files)),
+            runfiles = ctx.runfiles(files = all_files.to_list()),
         ),
-
         # We also define our own provider struct, for aggregation and testing.
         SkylarkLibraryInfo(
             srcs = ctx.files.srcs,


### PR DESCRIPTION
This enables --all_incompatible_changes with Bazel 0.16. With this change, when things are deprecated in the future, builds will fail, and the deprecated features can be changed before they are actually removed from Bazel/Starlark.