### PR TITLE
Remove usage and suggests for lib.bzl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ build rules in Bazel.
 
 Each of the `.bzl` files in the `lib` directory defines a "module"&mdash;a
 `struct` that contains a set of related functions and/or other symbols that can
-be loaded as a single unit, for convenience. The top-level file `lib.bzl` acts
-as an index from which the other modules can be imported.
+be loaded as a single unit, for convenience.
 
 ## Getting Started
 
@@ -30,17 +29,18 @@ git_repository(
 ```
 
 Then, in the `BUILD` and/or `*.bzl` files in your own workspace, you can load
-the modules (listed [below](#list-of-modules)) from `lib.bzl` and access the
-symbols by dotting into those structs:
+the modules (listed [below](#list-of-modules)) and access the symbols by
+dotting into those structs:
 
 ```python
-load("@bazel_skylib//:lib.bzl", "paths", "shell")
+load("@bazel_skylib//lib/paths.bzl", "paths")
+load("@bazel_skylib//lib/shell.bzl", "shell")
 
 p = paths.basename("foo.bar")
 s = shell.quote(p)
 ```
 
-## List of modules
+## List of modules (in lib/)
 
 * [collections](lib/collections.bzl)
 * [dicts](lib/dicts.bzl)
@@ -76,20 +76,6 @@ Steps to add a module to Skylib:
    things = struct(
        manipulate=_manipulate,
    )
-   ```
-
-1. Add a line to `lib.bzl` to make the new module accessible from the index:
-
-   ```python
-   load("@bazel_skylib//lib:things.bzl", "things")
-   ```
-
-1. Clients can then use the module by loading it from `lib.bzl`:
-
-   ```python
-   load("@bazel_skylib//:lib.bzl", "things")
-
-   things.manipulate()
    ```
 
 1. Add unit tests for your module in the `tests` directory.

--- a/tests/collections_tests.bzl
+++ b/tests/collections_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for collections.bzl."""
 
-load("//:lib.bzl", "asserts", "collections", "unittest")
+load("//lib:collections.bzl", "collections")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _after_each_test(ctx):
     """Unit tests for collections.after_each."""

--- a/tests/dicts_tests.bzl
+++ b/tests/dicts_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for dicts.bzl."""
 
-load("//:lib.bzl", "asserts", "dicts", "unittest")
+load("//lib:dicts.bzl", "dicts")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _add_test(ctx):
     """Unit tests for dicts.add."""

--- a/tests/new_sets_tests.bzl
+++ b/tests/new_sets_tests.bzl
@@ -14,181 +14,182 @@
 
 """Unit tests for new_sets.bzl."""
 
-load("//:lib.bzl", "asserts", "new_sets", "unittest")
+load("//lib:new_sets.bzl", "sets")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _is_equal_test(ctx):
-    """Unit tests for new_sets.is_equal."""
+    """Unit tests for sets.is_equal."""
 
     # Note that if this test fails, the results for the other `sets` tests will
     # be inconclusive because they use `asserts.new_set_equals`, which in turn
-    # calls `new_sets.is_equal`.
+    # calls `sets.is_equal`.
     env = unittest.begin(ctx)
 
-    asserts.true(env, new_sets.is_equal(new_sets.make(), new_sets.make()))
-    asserts.false(env, new_sets.is_equal(new_sets.make(), new_sets.make([1])))
-    asserts.false(env, new_sets.is_equal(new_sets.make([1]), new_sets.make()))
-    asserts.true(env, new_sets.is_equal(new_sets.make([1]), new_sets.make([1])))
-    asserts.false(env, new_sets.is_equal(new_sets.make([1]), new_sets.make([1, 2])))
-    asserts.false(env, new_sets.is_equal(new_sets.make([1]), new_sets.make([2])))
-    asserts.false(env, new_sets.is_equal(new_sets.make([1]), new_sets.make([1, 2])))
+    asserts.true(env, sets.is_equal(sets.make(), sets.make()))
+    asserts.false(env, sets.is_equal(sets.make(), sets.make([1])))
+    asserts.false(env, sets.is_equal(sets.make([1]), sets.make()))
+    asserts.true(env, sets.is_equal(sets.make([1]), sets.make([1])))
+    asserts.false(env, sets.is_equal(sets.make([1]), sets.make([1, 2])))
+    asserts.false(env, sets.is_equal(sets.make([1]), sets.make([2])))
+    asserts.false(env, sets.is_equal(sets.make([1]), sets.make([1, 2])))
 
     # Verify that the implementation is not using == on the sets directly.
-    asserts.true(env, new_sets.is_equal(new_sets.make(depset([1])), new_sets.make(depset([1]))))
+    asserts.true(env, sets.is_equal(sets.make(depset([1])), sets.make(depset([1]))))
 
     # If passing a list, verify that duplicate elements are ignored.
-    asserts.true(env, new_sets.is_equal(new_sets.make([1, 1]), new_sets.make([1])))
+    asserts.true(env, sets.is_equal(sets.make([1, 1]), sets.make([1])))
 
     unittest.end(env)
 
 is_equal_test = unittest.make(_is_equal_test)
 
 def _is_subset_test(ctx):
-    """Unit tests for new_sets.is_subset."""
+    """Unit tests for sets.is_subset."""
     env = unittest.begin(ctx)
 
-    asserts.true(env, new_sets.is_subset(new_sets.make(), new_sets.make()))
-    asserts.true(env, new_sets.is_subset(new_sets.make(), new_sets.make([1])))
-    asserts.false(env, new_sets.is_subset(new_sets.make([1]), new_sets.make()))
-    asserts.true(env, new_sets.is_subset(new_sets.make([1]), new_sets.make([1])))
-    asserts.true(env, new_sets.is_subset(new_sets.make([1]), new_sets.make([1, 2])))
-    asserts.false(env, new_sets.is_subset(new_sets.make([1]), new_sets.make([2])))
-    asserts.true(env, new_sets.is_subset(new_sets.make([1]), new_sets.make(depset([1, 2]))))
+    asserts.true(env, sets.is_subset(sets.make(), sets.make()))
+    asserts.true(env, sets.is_subset(sets.make(), sets.make([1])))
+    asserts.false(env, sets.is_subset(sets.make([1]), sets.make()))
+    asserts.true(env, sets.is_subset(sets.make([1]), sets.make([1])))
+    asserts.true(env, sets.is_subset(sets.make([1]), sets.make([1, 2])))
+    asserts.false(env, sets.is_subset(sets.make([1]), sets.make([2])))
+    asserts.true(env, sets.is_subset(sets.make([1]), sets.make(depset([1, 2]))))
 
     # If passing a list, verify that duplicate elements are ignored.
-    asserts.true(env, new_sets.is_subset(new_sets.make([1, 1]), new_sets.make([1, 2])))
+    asserts.true(env, sets.is_subset(sets.make([1, 1]), sets.make([1, 2])))
 
     unittest.end(env)
 
 is_subset_test = unittest.make(_is_subset_test)
 
 def _disjoint_test(ctx):
-    """Unit tests for new_sets.disjoint."""
+    """Unit tests for sets.disjoint."""
     env = unittest.begin(ctx)
 
-    asserts.true(env, new_sets.disjoint(new_sets.make(), new_sets.make()))
-    asserts.true(env, new_sets.disjoint(new_sets.make(), new_sets.make([1])))
-    asserts.true(env, new_sets.disjoint(new_sets.make([1]), new_sets.make()))
-    asserts.false(env, new_sets.disjoint(new_sets.make([1]), new_sets.make([1])))
-    asserts.false(env, new_sets.disjoint(new_sets.make([1]), new_sets.make([1, 2])))
-    asserts.true(env, new_sets.disjoint(new_sets.make([1]), new_sets.make([2])))
-    asserts.true(env, new_sets.disjoint(new_sets.make([1]), new_sets.make(depset([2]))))
+    asserts.true(env, sets.disjoint(sets.make(), sets.make()))
+    asserts.true(env, sets.disjoint(sets.make(), sets.make([1])))
+    asserts.true(env, sets.disjoint(sets.make([1]), sets.make()))
+    asserts.false(env, sets.disjoint(sets.make([1]), sets.make([1])))
+    asserts.false(env, sets.disjoint(sets.make([1]), sets.make([1, 2])))
+    asserts.true(env, sets.disjoint(sets.make([1]), sets.make([2])))
+    asserts.true(env, sets.disjoint(sets.make([1]), sets.make(depset([2]))))
 
     # If passing a list, verify that duplicate elements are ignored.
-    asserts.false(env, new_sets.disjoint(new_sets.make([1, 1]), new_sets.make([1, 2])))
+    asserts.false(env, sets.disjoint(sets.make([1, 1]), sets.make([1, 2])))
 
     unittest.end(env)
 
 disjoint_test = unittest.make(_disjoint_test)
 
 def _intersection_test(ctx):
-    """Unit tests for new_sets.intersection."""
+    """Unit tests for sets.intersection."""
     env = unittest.begin(ctx)
 
-    asserts.new_set_equals(env, new_sets.make(), new_sets.intersection(new_sets.make(), new_sets.make()))
-    asserts.new_set_equals(env, new_sets.make(), new_sets.intersection(new_sets.make(), new_sets.make([1])))
-    asserts.new_set_equals(env, new_sets.make(), new_sets.intersection(new_sets.make([1]), new_sets.make()))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.intersection(new_sets.make([1]), new_sets.make([1])))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.intersection(new_sets.make([1]), new_sets.make([1, 2])))
-    asserts.new_set_equals(env, new_sets.make(), new_sets.intersection(new_sets.make([1]), new_sets.make([2])))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.intersection(new_sets.make([1]), new_sets.make(depset([1]))))
+    asserts.new_set_equals(env, sets.make(), sets.intersection(sets.make(), sets.make()))
+    asserts.new_set_equals(env, sets.make(), sets.intersection(sets.make(), sets.make([1])))
+    asserts.new_set_equals(env, sets.make(), sets.intersection(sets.make([1]), sets.make()))
+    asserts.new_set_equals(env, sets.make([1]), sets.intersection(sets.make([1]), sets.make([1])))
+    asserts.new_set_equals(env, sets.make([1]), sets.intersection(sets.make([1]), sets.make([1, 2])))
+    asserts.new_set_equals(env, sets.make(), sets.intersection(sets.make([1]), sets.make([2])))
+    asserts.new_set_equals(env, sets.make([1]), sets.intersection(sets.make([1]), sets.make(depset([1]))))
 
     # If passing a list, verify that duplicate elements are ignored.
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.intersection(new_sets.make([1, 1]), new_sets.make([1, 2])))
+    asserts.new_set_equals(env, sets.make([1]), sets.intersection(sets.make([1, 1]), sets.make([1, 2])))
 
     unittest.end(env)
 
 intersection_test = unittest.make(_intersection_test)
 
 def _union_test(ctx):
-    """Unit tests for new_sets.union."""
+    """Unit tests for sets.union."""
     env = unittest.begin(ctx)
 
-    asserts.new_set_equals(env, new_sets.make(), new_sets.union())
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.union(new_sets.make([1])))
-    asserts.new_set_equals(env, new_sets.make(), new_sets.union(new_sets.make(), new_sets.make()))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.union(new_sets.make(), new_sets.make([1])))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.union(new_sets.make([1]), new_sets.make()))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.union(new_sets.make([1]), new_sets.make([1])))
-    asserts.new_set_equals(env, new_sets.make([1, 2]), new_sets.union(new_sets.make([1]), new_sets.make([1, 2])))
-    asserts.new_set_equals(env, new_sets.make([1, 2]), new_sets.union(new_sets.make([1]), new_sets.make([2])))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.union(new_sets.make([1]), new_sets.make(depset([1]))))
+    asserts.new_set_equals(env, sets.make(), sets.union())
+    asserts.new_set_equals(env, sets.make([1]), sets.union(sets.make([1])))
+    asserts.new_set_equals(env, sets.make(), sets.union(sets.make(), sets.make()))
+    asserts.new_set_equals(env, sets.make([1]), sets.union(sets.make(), sets.make([1])))
+    asserts.new_set_equals(env, sets.make([1]), sets.union(sets.make([1]), sets.make()))
+    asserts.new_set_equals(env, sets.make([1]), sets.union(sets.make([1]), sets.make([1])))
+    asserts.new_set_equals(env, sets.make([1, 2]), sets.union(sets.make([1]), sets.make([1, 2])))
+    asserts.new_set_equals(env, sets.make([1, 2]), sets.union(sets.make([1]), sets.make([2])))
+    asserts.new_set_equals(env, sets.make([1]), sets.union(sets.make([1]), sets.make(depset([1]))))
 
     # If passing a list, verify that duplicate elements are ignored.
-    asserts.new_set_equals(env, new_sets.make([1, 2]), new_sets.union(new_sets.make([1, 1]), new_sets.make([1, 2])))
+    asserts.new_set_equals(env, sets.make([1, 2]), sets.union(sets.make([1, 1]), sets.make([1, 2])))
 
     unittest.end(env)
 
 union_test = unittest.make(_union_test)
 
 def _difference_test(ctx):
-    """Unit tests for new_sets.difference."""
+    """Unit tests for sets.difference."""
     env = unittest.begin(ctx)
 
-    asserts.new_set_equals(env, new_sets.make(), new_sets.difference(new_sets.make(), new_sets.make()))
-    asserts.new_set_equals(env, new_sets.make(), new_sets.difference(new_sets.make(), new_sets.make([1])))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.difference(new_sets.make([1]), new_sets.make()))
-    asserts.new_set_equals(env, new_sets.make(), new_sets.difference(new_sets.make([1]), new_sets.make([1])))
-    asserts.new_set_equals(env, new_sets.make(), new_sets.difference(new_sets.make([1]), new_sets.make([1, 2])))
-    asserts.new_set_equals(env, new_sets.make([1]), new_sets.difference(new_sets.make([1]), new_sets.make([2])))
-    asserts.new_set_equals(env, new_sets.make(), new_sets.difference(new_sets.make([1]), new_sets.make(depset([1]))))
+    asserts.new_set_equals(env, sets.make(), sets.difference(sets.make(), sets.make()))
+    asserts.new_set_equals(env, sets.make(), sets.difference(sets.make(), sets.make([1])))
+    asserts.new_set_equals(env, sets.make([1]), sets.difference(sets.make([1]), sets.make()))
+    asserts.new_set_equals(env, sets.make(), sets.difference(sets.make([1]), sets.make([1])))
+    asserts.new_set_equals(env, sets.make(), sets.difference(sets.make([1]), sets.make([1, 2])))
+    asserts.new_set_equals(env, sets.make([1]), sets.difference(sets.make([1]), sets.make([2])))
+    asserts.new_set_equals(env, sets.make(), sets.difference(sets.make([1]), sets.make(depset([1]))))
 
     # If passing a list, verify that duplicate elements are ignored.
-    asserts.new_set_equals(env, new_sets.make([2]), new_sets.difference(new_sets.make([1, 2]), new_sets.make([1, 1])))
+    asserts.new_set_equals(env, sets.make([2]), sets.difference(sets.make([1, 2]), sets.make([1, 1])))
 
     unittest.end(env)
 
 difference_test = unittest.make(_difference_test)
 
 def _to_list_test(ctx):
-    """Unit tests for new_sets.to_list."""
+    """Unit tests for sets.to_list."""
     env = unittest.begin(ctx)
 
-    asserts.equals(env, [], new_sets.to_list(new_sets.make()))
-    asserts.equals(env, [1], new_sets.to_list(new_sets.make([1, 1, 1])))
-    asserts.equals(env, [1, 2, 3], new_sets.to_list(new_sets.make([1, 2, 3])))
+    asserts.equals(env, [], sets.to_list(sets.make()))
+    asserts.equals(env, [1], sets.to_list(sets.make([1, 1, 1])))
+    asserts.equals(env, [1, 2, 3], sets.to_list(sets.make([1, 2, 3])))
 
     unittest.end(env)
 
 to_list_test = unittest.make(_to_list_test)
 
 def _make_test(ctx):
-    """Unit tests for new_sets.make."""
+    """Unit tests for sets.make."""
     env = unittest.begin(ctx)
 
-    asserts.equals(env, {}, new_sets.make()._values)
-    asserts.equals(env, {x: None for x in [1, 2, 3]}, new_sets.make([1, 1, 2, 2, 3, 3])._values)
-    asserts.equals(env, {1: None, 2: None}, new_sets.make(depset([1, 2]))._values)
+    asserts.equals(env, {}, sets.make()._values)
+    asserts.equals(env, {x: None for x in [1, 2, 3]}, sets.make([1, 1, 2, 2, 3, 3])._values)
+    asserts.equals(env, {1: None, 2: None}, sets.make(depset([1, 2]))._values)
 
     unittest.end(env)
 
 make_test = unittest.make(_make_test)
 
 def _copy_test(ctx):
-    """Unit tests for new_sets.copy."""
+    """Unit tests for sets.copy."""
     env = unittest.begin(ctx)
 
-    asserts.new_set_equals(env, new_sets.copy(new_sets.make()), new_sets.make())
-    asserts.new_set_equals(env, new_sets.copy(new_sets.make([1, 2, 3])), new_sets.make([1, 2, 3]))
+    asserts.new_set_equals(env, sets.copy(sets.make()), sets.make())
+    asserts.new_set_equals(env, sets.copy(sets.make([1, 2, 3])), sets.make([1, 2, 3]))
 
     # Ensure mutating the copy does not mutate the original
-    original = new_sets.make([1, 2, 3])
-    copy = new_sets.copy(original)
+    original = sets.make([1, 2, 3])
+    copy = sets.copy(original)
     copy._values[5] = None
-    asserts.false(env, new_sets.is_equal(original, copy))
+    asserts.false(env, sets.is_equal(original, copy))
 
     unittest.end(env)
 
 copy_test = unittest.make(_copy_test)
 
 def _insert_test(ctx):
-    """Unit tests for new_sets.insert."""
+    """Unit tests for sets.insert."""
     env = unittest.begin(ctx)
 
-    asserts.new_set_equals(env, new_sets.make([1, 2, 3]), new_sets.insert(new_sets.make([1, 2]), 3))
+    asserts.new_set_equals(env, sets.make([1, 2, 3]), sets.insert(sets.make([1, 2]), 3))
 
     # Ensure mutating the inserted set does mutate the original set.
-    original = new_sets.make([1, 2, 3])
-    after_insert = new_sets.insert(original, 4)
+    original = sets.make([1, 2, 3])
+    after_insert = sets.insert(original, 4)
     asserts.new_set_equals(
         env,
         original,
@@ -201,39 +202,39 @@ def _insert_test(ctx):
 insert_test = unittest.make(_insert_test)
 
 def _contains_test(ctx):
-    """Unit tests for new_sets.contains."""
+    """Unit tests for sets.contains."""
     env = unittest.begin(ctx)
 
-    asserts.false(env, new_sets.contains(new_sets.make(), 1))
-    asserts.true(env, new_sets.contains(new_sets.make([1]), 1))
-    asserts.true(env, new_sets.contains(new_sets.make([1, 2]), 1))
-    asserts.false(env, new_sets.contains(new_sets.make([2, 3]), 1))
+    asserts.false(env, sets.contains(sets.make(), 1))
+    asserts.true(env, sets.contains(sets.make([1]), 1))
+    asserts.true(env, sets.contains(sets.make([1, 2]), 1))
+    asserts.false(env, sets.contains(sets.make([2, 3]), 1))
 
     unittest.end(env)
 
 contains_test = unittest.make(_contains_test)
 
 def _length_test(ctx):
-    """Unit test for new_sets.length."""
+    """Unit test for sets.length."""
     env = unittest.begin(ctx)
 
-    asserts.equals(env, 0, new_sets.length(new_sets.make()))
-    asserts.equals(env, 1, new_sets.length(new_sets.make([1])))
-    asserts.equals(env, 2, new_sets.length(new_sets.make([1, 2])))
+    asserts.equals(env, 0, sets.length(sets.make()))
+    asserts.equals(env, 1, sets.length(sets.make([1])))
+    asserts.equals(env, 2, sets.length(sets.make([1, 2])))
 
     unittest.end(env)
 
 length_test = unittest.make(_length_test)
 
 def _remove_test(ctx):
-    """Unit test for new_sets.remove."""
+    """Unit test for sets.remove."""
     env = unittest.begin(ctx)
 
-    asserts.new_set_equals(env, new_sets.make([1, 2]), new_sets.remove(new_sets.make([1, 2, 3]), 3))
+    asserts.new_set_equals(env, sets.make([1, 2]), sets.remove(sets.make([1, 2, 3]), 3))
 
     # Ensure mutating the inserted set does mutate the original set.
-    original = new_sets.make([1, 2, 3])
-    after_removal = new_sets.remove(original, 3)
+    original = sets.make([1, 2, 3])
+    after_removal = sets.remove(original, 3)
     asserts.new_set_equals(env, original, after_removal)
 
     unittest.end(env)
@@ -241,16 +242,16 @@ def _remove_test(ctx):
 remove_test = unittest.make(_remove_test)
 
 def _repr_str_test(ctx):
-    """Unit test for new_sets.repr and new_sets.str."""
+    """Unit test for sets.repr and sets.str."""
     env = unittest.begin(ctx)
 
-    asserts.equals(env, "[]", new_sets.repr(new_sets.make()))
-    asserts.equals(env, "[1]", new_sets.repr(new_sets.make([1])))
-    asserts.equals(env, "[1, 2]", new_sets.repr(new_sets.make([1, 2])))
+    asserts.equals(env, "[]", sets.repr(sets.make()))
+    asserts.equals(env, "[1]", sets.repr(sets.make([1])))
+    asserts.equals(env, "[1, 2]", sets.repr(sets.make([1, 2])))
 
-    asserts.equals(env, "[]", new_sets.str(new_sets.make()))
-    asserts.equals(env, "[1]", new_sets.str(new_sets.make([1])))
-    asserts.equals(env, "[1, 2]", new_sets.str(new_sets.make([1, 2])))
+    asserts.equals(env, "[]", sets.str(sets.make()))
+    asserts.equals(env, "[1]", sets.str(sets.make([1])))
+    asserts.equals(env, "[1, 2]", sets.str(sets.make([1, 2])))
 
     unittest.end(env)
 

--- a/tests/partial_tests.bzl
+++ b/tests/partial_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for partial.bzl."""
 
-load("//:lib.bzl", "asserts", "partial", "unittest")
+load("//lib:partial.bzl", "partial")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _make_noargs_nokwargs():
     """Test utility for no args no kwargs case"""

--- a/tests/paths_tests.bzl
+++ b/tests/paths_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for paths.bzl."""
 
-load("//:lib.bzl", "asserts", "paths", "unittest")
+load("//lib:paths.bzl", "paths")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _basename_test(ctx):
     """Unit tests for paths.basename."""

--- a/tests/selects_tests.bzl
+++ b/tests/selects_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for selects.bzl."""
 
-load("//:lib.bzl", "asserts", "selects", "unittest")
+load("//lib:selects.bzl", "selects")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _with_or_test(ctx):
     """Unit tests for with_or."""

--- a/tests/sets_tests.bzl
+++ b/tests/sets_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for sets.bzl."""
 
-load("//:lib.bzl", "asserts", "sets", "unittest")
+load("//lib:sets.bzl", "sets")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _is_equal_test(ctx):
     """Unit tests for sets.is_equal."""

--- a/tests/shell_tests.bzl
+++ b/tests/shell_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for shell.bzl."""
 
-load("//:lib.bzl", "asserts", "shell", "unittest")
+load("//lib:shell.bzl", "shell")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _shell_array_literal_test(ctx):
     """Unit tests for shell.array_literal."""

--- a/tests/structs_tests.bzl
+++ b/tests/structs_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for structs.bzl."""
 
-load("//:lib.bzl", "asserts", "structs", "unittest")
+load("//lib:structs.bzl", "structs")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _add_test(ctx):
     """Unit tests for dicts.add."""

--- a/tests/types_tests.bzl
+++ b/tests/types_tests.bzl
@@ -13,7 +13,8 @@
 # limitations under the License.
 """Unit tests for types.bzl."""
 
-load("//:lib.bzl", "asserts", "types", "unittest")
+load("//lib:types.bzl", "types")
+load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _a_function():
     """A dummy function for testing."""

--- a/tests/versions_tests.bzl
+++ b/tests/versions_tests.bzl
@@ -14,7 +14,8 @@
 
 """Unit tests for versions.bzl."""
 
-load("//:lib.bzl", "asserts", "unittest", "versions")
+load("//lib:unittest.bzl", "asserts", "unittest")
+load("//lib:versions.bzl", "versions")
 
 def _parse_test(ctx):
     """Unit tests for versions.parse"""


### PR DESCRIPTION
As more things are added, lib.bzl is an anti-pattern as the cost of loading
it actually just keeps increasing and most things will never use everything
out of it.  The pattern the should be used is to directly import the modules
one uses.