### PR TITLE
Rename a number of instances of 'skylark' to 'starlark'

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("//:skylark_library.bzl", "skylark_library")
+load("//:starlark_library.bzl", "starlark_library")
 
 exports_files([
     "LICENSE",
@@ -18,7 +18,7 @@ filegroup(
     ] + glob(["*.bzl"]),
 )
 
-skylark_library(
+starlark_library(
     name = "lib",
     srcs = ["lib.bzl"],
     deprecation = (
@@ -41,7 +41,7 @@ skylark_library(
     ],
 )
 
-skylark_library(
-    name = "skylark_library",
-    srcs = ["skylark_library.bzl"],
+starlark_library(
+    name = "starlark_library",
+    srcs = ["starlark_library.bzl"],
 )

--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//visibility:public"])
 
-load("//:starlark_library.bzl", "starlark_library")
+load("//:bzl_library.bzl", "bzl_library")
 
 exports_files([
     "LICENSE",
@@ -18,7 +18,7 @@ filegroup(
     ] + glob(["*.bzl"]),
 )
 
-starlark_library(
+bzl_library(
     name = "lib",
     srcs = ["lib.bzl"],
     deprecation = (
@@ -41,7 +41,7 @@ starlark_library(
     ],
 )
 
-starlark_library(
-    name = "starlark_library",
-    srcs = ["starlark_library.bzl"],
+bzl_library(
+    name = "bzl_library",
+    srcs = ["bzl_library.bzl"],
 )

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Steps to add a module to Skylib:
 
 1. Add unit tests for your module in the `tests` directory.
 
-## `starlark_library`
+## `bzl_library`
 
-The `starlark_library.bzl` rule can be used to aggregate a set of
+The `bzl_library.bzl` rule can be used to aggregate a set of
 Starlark files and its dependencies for use in test targets and
 documentation generation.

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Steps to add a module to Skylib:
 
 1. Add unit tests for your module in the `tests` directory.
 
-## `skylark_library`
+## `starlark_library`
 
-The `skylark_library.bzl` rule can be used to aggregate a set of
-Skylark files and its dependencies for use in test targets and
+The `starlark_library.bzl` rule can be used to aggregate a set of
+Starlark files and its dependencies for use in test targets and
 documentation generation.

--- a/bzl_library.bzl
+++ b/bzl_library.bzl
@@ -23,12 +23,12 @@ StarlarkLibraryInfo = provider(
     },
 )
 
-def _starlark_library_impl(ctx):
+def _bzl_library_impl(ctx):
     deps_files = [depset(x.files, order = "postorder") for x in ctx.attr.deps]
     all_files = depset(ctx.files.srcs, order = "postorder", transitive = deps_files)
     return [
         # All dependent files should be listed in both `files` and in `runfiles`;
-        # this ensures that a `starlark_library` can be referenced as `data` from
+        # this ensures that a `bzl_library` can be referenced as `data` from
         # a separate program, or from `tools` of a genrule().
         DefaultInfo(
             files = all_files,
@@ -42,8 +42,8 @@ def _starlark_library_impl(ctx):
         ),
     ]
 
-starlark_library = rule(
-    implementation = _starlark_library_impl,
+bzl_library = rule(
+    implementation = _bzl_library_impl,
     attrs = {
         "srcs": attr.label_list(
             allow_files = [".bzl"],
@@ -60,7 +60,7 @@ starlark_library = rule(
 
 Args:
   srcs: List of `.bzl` files that are processed to create this target.
-  deps: List of other `starlark_library` targets that are required by the
+  deps: List of other `bzl_library` targets that are required by the
     Starlark files listed in `srcs`.
 
 Example:
@@ -79,15 +79,15 @@ Example:
           luarocks.bzl
   ```
 
-  In this case, you can have `starlark_library` targets in `checkstyle/BUILD` and
+  In this case, you can have `bzl_library` targets in `checkstyle/BUILD` and
   `lua/BUILD`:
 
   `checkstyle/BUILD`:
 
   ```python
-  load("@bazel_skylib//:starlark_library.bzl", "starlark_library")
+  load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-  starlark_library(
+  bzl_library(
       name = "checkstyle-rules",
       srcs = ["checkstyle.bzl"],
   )
@@ -96,9 +96,9 @@ Example:
   `lua/BUILD`:
 
   ```python
-  load("@bazel_skylib//:starlark_library.bzl", "starlark_library")
+  load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-  starlark_library(
+  bzl_library(
       name = "lua-rules",
       srcs = [
           "lua.bzl",

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//:starlark_library.bzl", "starlark_library")
+load("//:bzl_library.bzl", "bzl_library")
 
 filegroup(
     name = "test_deps",
@@ -10,63 +10,63 @@ filegroup(
     srcs = ["BUILD"] + glob(["*.bzl"]),
 )
 
-starlark_library(
+bzl_library(
     name = "collections",
     srcs = ["collections.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "dicts",
     srcs = ["dicts.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "partial",
     srcs = ["partial.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "paths",
     srcs = ["paths.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "selects",
     srcs = ["selects.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "sets",
     srcs = ["sets.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "new_sets",
     srcs = ["new_sets.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "shell",
     srcs = ["shell.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "structs",
     srcs = ["structs.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "types",
     srcs = ["types.bzl"],
 )
 
-starlark_library(
+bzl_library(
     name = "unittest",
     srcs = ["unittest.bzl"],
     deps = [":sets"],
 )
 
-starlark_library(
+bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],
 )

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//:skylark_library.bzl", "skylark_library")
+load("//:starlark_library.bzl", "starlark_library")
 
 filegroup(
     name = "test_deps",
@@ -10,63 +10,63 @@ filegroup(
     srcs = ["BUILD"] + glob(["*.bzl"]),
 )
 
-skylark_library(
+starlark_library(
     name = "collections",
     srcs = ["collections.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "dicts",
     srcs = ["dicts.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "partial",
     srcs = ["partial.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "paths",
     srcs = ["paths.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "selects",
     srcs = ["selects.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "sets",
     srcs = ["sets.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "new_sets",
     srcs = ["new_sets.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "shell",
     srcs = ["shell.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "structs",
     srcs = ["structs.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "types",
     srcs = ["types.bzl"],
 )
 
-skylark_library(
+starlark_library(
     name = "unittest",
     srcs = ["unittest.bzl"],
     deps = [":sets"],
 )
 
-skylark_library(
+starlark_library(
     name = "versions",
     srcs = ["versions.bzl"],
 )

--- a/lib/partial.bzl
+++ b/lib/partial.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Skylark module for working with partial function objects.
+"""Starlark module for working with partial function objects.
 
 Partial function objects allow some parameters are bound before the call.
 

--- a/lib/selects.bzl
+++ b/lib/selects.bzl
@@ -54,7 +54,7 @@ def _with_or(input_dict, no_match_error = ""):
 def _with_or_dict(input_dict):
     """Variation of `with_or` that returns the dict of the `select()`.
 
-    Unlike `select()`, the contents of the dict can be inspected by Skylark
+    Unlike `select()`, the contents of the dict can be inspected by Starlark
     macros.
 
     Args:

--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -59,7 +59,7 @@ def _make(impl, attrs = None):
     """
 
     # Derive the name of the implementation function for better test feedback.
-    # Skylark currently stringifies a function as "<function NAME>", so we use
+    # Starlark currently stringifies a function as "<function NAME>", so we use
     # that knowledge to parse the "NAME" portion out. If this behavior ever
     # changes, we'll need to update this.
     # TODO(bazel-team): Expose a ._name field on functions to avoid this.

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -1,0 +1,7 @@
+load("//:bzl_library.bzl", "StarlarkLibraryInfo", "bzl_library")
+
+# These are temporary forwarding macros to facilitate migration to
+# the new names for these objects.
+SkylarkLibraryInfo = StarlarkLibraryInfo
+
+skylark_library = bzl_library

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -1,3 +1,8 @@
+print(
+    "WARNING: skylark_library.bzl is deprecated and will go away in the future, please" +
+    " use bzl_library.bzl instead.",
+ )
+
 load("//:bzl_library.bzl", "StarlarkLibraryInfo", "bzl_library")
 
 # These are temporary forwarding macros to facilitate migration to
@@ -5,3 +10,4 @@ load("//:bzl_library.bzl", "StarlarkLibraryInfo", "bzl_library")
 SkylarkLibraryInfo = StarlarkLibraryInfo
 
 skylark_library = bzl_library
+

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -1,7 +1,7 @@
 print(
     "WARNING: skylark_library.bzl is deprecated and will go away in the future, please" +
     " use bzl_library.bzl instead.",
- )
+)
 
 load("//:bzl_library.bzl", "StarlarkLibraryInfo", "bzl_library")
 

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -10,4 +10,3 @@ load("//:bzl_library.bzl", "StarlarkLibraryInfo", "bzl_library")
 SkylarkLibraryInfo = StarlarkLibraryInfo
 
 skylark_library = bzl_library
-

--- a/starlark_library.bzl
+++ b/starlark_library.bzl
@@ -14,8 +14,8 @@
 
 """Skylib module containing a library rule for aggregating rules files."""
 
-SkylarkLibraryInfo = provider(
-    "Information on contained Skylark rules.",
+StarlarkLibraryInfo = provider(
+    "Information on contained Starlark rules.",
     fields = {
         "srcs": "Top level rules files.",
         "transitive_srcs": "Transitive closure of rules files required for " +
@@ -23,12 +23,12 @@ SkylarkLibraryInfo = provider(
     },
 )
 
-def _skylark_library_impl(ctx):
+def _starlark_library_impl(ctx):
     deps_files = [depset(x.files, order = "postorder") for x in ctx.attr.deps]
     all_files = depset(ctx.files.srcs, order = "postorder", transitive = deps_files)
     return [
         # All dependent files should be listed in both `files` and in `runfiles`;
-        # this ensures that a `skylark_library` can be referenced as `data` from
+        # this ensures that a `starlark_library` can be referenced as `data` from
         # a separate program, or from `tools` of a genrule().
         DefaultInfo(
             files = all_files,
@@ -36,14 +36,14 @@ def _skylark_library_impl(ctx):
         ),
 
         # We also define our own provider struct, for aggregation and testing.
-        SkylarkLibraryInfo(
+        StarlarkLibraryInfo(
             srcs = ctx.files.srcs,
             transitive_srcs = all_files,
         ),
     ]
 
-skylark_library = rule(
-    implementation = _skylark_library_impl,
+starlark_library = rule(
+    implementation = _starlark_library_impl,
     attrs = {
         "srcs": attr.label_list(
             allow_files = [".bzl"],
@@ -51,17 +51,17 @@ skylark_library = rule(
         "deps": attr.label_list(
             allow_files = [".bzl"],
             providers = [
-                [SkylarkLibraryInfo],
+                [StarlarkLibraryInfo],
             ],
         ),
     },
 )
-"""Creates a logical collection of Skylark .bzl files.
+"""Creates a logical collection of Starlark .bzl files.
 
 Args:
   srcs: List of `.bzl` files that are processed to create this target.
-  deps: List of other `skylark_library` targets that are required by the
-    Skylark files listed in `srcs`.
+  deps: List of other `starlark_library` targets that are required by the
+    Starlark files listed in `srcs`.
 
 Example:
   Suppose your project has the following structure:
@@ -79,15 +79,15 @@ Example:
           luarocks.bzl
   ```
 
-  In this case, you can have `skylark_library` targets in `checkstyle/BUILD` and
+  In this case, you can have `starlark_library` targets in `checkstyle/BUILD` and
   `lua/BUILD`:
 
   `checkstyle/BUILD`:
 
   ```python
-  load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+  load("@bazel_skylib//:starlark_library.bzl", "starlark_library")
 
-  skylark_library(
+  starlark_library(
       name = "checkstyle-rules",
       srcs = ["checkstyle.bzl"],
   )
@@ -96,9 +96,9 @@ Example:
   `lua/BUILD`:
 
   ```python
-  load("@bazel_skylib//:skylark_library.bzl", "skylark_library")
+  load("@bazel_skylib//:starlark_library.bzl", "starlark_library")
 
-  skylark_library(
+  starlark_library(
       name = "lua-rules",
       srcs = [
           "lua.bzl",

--- a/tests/selects_tests.bzl
+++ b/tests/selects_tests.bzl
@@ -21,7 +21,7 @@ def _with_or_test(ctx):
     """Unit tests for with_or."""
     env = unittest.begin(ctx)
 
-    # We actually test on with_or_dict because Skylark can't get the
+    # We actually test on with_or_dict because Starlark can't get the
     # dictionary from a select().
 
     # Test select()-compatible input syntax.


### PR DESCRIPTION
Most notably, this renames/moves a few important identifiers:

//:skylark_library.bzl -> //:starlark_library.bzl
skylark_library -> starlark_libary
SkylarkLibraryInfo -> StarlarkLibraryInfo
