### PR TITLE
Add a repository.bzl helper

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -46,6 +46,11 @@ bzl_library(
 )
 
 bzl_library(
+    name = "repository",
+    srcs = ["repository.bzl"],
+)
+
+bzl_library(
     name = "shell",
     srcs = ["shell.bzl"],
 )

--- a/lib/repository.bzl
+++ b/lib/repository.bzl
@@ -1,7 +1,12 @@
 """Helpers for creating repository rules.
 """
 
-def maybe(repo_rule, name, **kwargs):
+def _maybe(repo_rule, name, **kwargs):
     """Conditionally define a repository if it does not already exist."""
     if name not in native.existing_rules():
         repo_rule(name = name, **kwargs)
+
+
+repository = struct(
+    maybe = _maybe,
+)

--- a/lib/repository.bzl
+++ b/lib/repository.bzl
@@ -1,9 +1,17 @@
 """Helpers for creating repository rules.
 """
 
-def _maybe(repo_rule, name, **kwargs):
-    """Conditionally define a repository if it does not already exist."""
-    if name not in native.existing_rules():
+def _maybe(repo_rule, name, existing_rules = None, **kwargs):
+    """Conditionally define a repository if it does not already exist.
+    
+    Args:
+      repo_rule: The function to invoke. e.g. http_archive, git_archive, etc.
+      name: The name to conditionally register.
+      existing_rules: the set of preexisting rules to compare. Used for testing. Defaults to native.existing_rules()
+    """
+    if not existing_rules:
+        existing_rules = native.existing_rules()
+    if name not in existing_rules:
         repo_rule(name = name, **kwargs)
 
 

--- a/lib/repository.bzl
+++ b/lib/repository.bzl
@@ -1,0 +1,7 @@
+"""Helpers for creating repository rules.
+"""
+
+def maybe(repo_rule, name, **kwargs):
+    """Conditionally define a repository if it does not already exist."""
+    if name not in native.existing_rules():
+        repo_rule(name = name, **kwargs)

--- a/lib/repository.bzl
+++ b/lib/repository.bzl
@@ -1,3 +1,16 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Helpers for creating repository rules.
 """
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -2,6 +2,7 @@ load(":collections_tests.bzl", "collections_test_suite")
 load(":dicts_tests.bzl", "dicts_test_suite")
 load(":partial_tests.bzl", "partial_test_suite")
 load(":paths_tests.bzl", "paths_test_suite")
+load(":repository_tests.bzl", "repository_test_suite")
 load(":selects_tests.bzl", "selects_test_suite")
 load(":sets_tests.bzl", "sets_test_suite")
 load(":new_sets_tests.bzl", "new_sets_test_suite")
@@ -25,6 +26,8 @@ selects_test_suite()
 sets_test_suite()
 
 new_sets_test_suite()
+
+repository_test_suite()
 
 shell_test_suite()
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,3 +1,16 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 load(":collections_tests.bzl", "collections_test_suite")
 load(":dicts_tests.bzl", "dicts_test_suite")
 load(":partial_tests.bzl", "partial_test_suite")

--- a/tests/repository_tests.bzl
+++ b/tests/repository_tests.bzl
@@ -16,31 +16,32 @@
 load("//lib:repository.bzl", "repository")
 load("//lib:unittest.bzl", "asserts", "unittest")
 
-def _calles_rule_function(ctx):
+_existing_rules = {}
+def _dummy_function(name):
+    """Used to validate the maybe function is/isn't called."""
+    _existing_rules[name] = (_existing_rules[name] or 0) + 1
+
+def _calls_rule_function(ctx):
     """Unit tests for repository.maybe."""
 
     env = unittest.begin(ctx)
     
-    existing_rules = {}
-    def _dummy_function(name):
-        """Used to validate the maybe function is/isn't called."""
-        existing_rules[name] = (existing_rules[name] or 0) + 1
 
     # It should insert the first time.
     repository.maybe(_dummy_function, "foo")
-    asserts.equals(env, existing_rules, {"foo": 1})
+    asserts.equals(env, _existing_rules, {"foo": 1})
 
     # And find a preexisting entry the second and not change it.
     repository.maybe(_dummy_function, "foo")
-    asserts.equals(env, existing_rules, {"foo": 1})
+    asserts.equals(env, _existing_rules, {"foo": 1})
 
     unittest.end(env)
 
-calles_rule_function = unittest.make(_calles_rule_function)
+calls_rule_function = unittest.make(_calls_rule_function)
 
 def repository_test_suite():
     """Creates the test targets and test suite for repository.bzl tests."""
     unittest.suite(
         "repository_tests",
-        calles_rule_function,
+        calls_rule_function,
     )

--- a/tests/repository_tests.bzl
+++ b/tests/repository_tests.bzl
@@ -1,0 +1,46 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for repository.bzl."""
+
+load("//lib:repository.bzl", "repository")
+load("//lib:unittest.bzl", "asserts", "unittest")
+
+def _calles_rule_function(ctx):
+    """Unit tests for repository.maybe."""
+
+    env = unittest.begin(ctx)
+    
+    existing_rules = {}
+    def _dummy_function(name):
+        """Used to validate the maybe function is/isn't called."""
+        existing_rules[name] = (existing_rules[name] or 0) + 1
+
+    # It should insert the first time.
+    repository.maybe(_dummy_function, "foo")
+    asserts.equals(env, existing_rules, {"foo": 1})
+
+    # And find a preexisting entry the second and not change it.
+    repository.maybe(_dummy_function, "foo")
+    asserts.equals(env, existing_rules, {"foo": 1})
+
+    unittest.end(env)
+
+calles_rule_function = unittest.make(_calles_rule_function)
+
+def repository_test_suite():
+    """Creates the test targets and test suite for repository.bzl tests."""
+    unittest.suite(
+        "repository_tests",
+        calles_rule_function,
+    )

--- a/tests/repository_tests.bzl
+++ b/tests/repository_tests.bzl
@@ -28,11 +28,11 @@ def _calls_rule_function_test(ctx):
     
     # It should insert the first time.
     repository.maybe(_dummy_function, "foo")
-    asserts.equals(env, _existing_rules, {"foo": 1}, _existing_rules)
+    asserts.equals(env, _existing_rules, {"foo": 1}, existing_rules = _existing_rules)
 
     # And find a preexisting entry the second and not change it.
     repository.maybe(_dummy_function, "foo")
-    asserts.equals(env, _existing_rules, {"foo": 1}, _existing_rules)
+    asserts.equals(env, _existing_rules, {"foo": 1}, existing_rules = _existing_rules)
 
     unittest.end(env)
 

--- a/tests/repository_tests.bzl
+++ b/tests/repository_tests.bzl
@@ -26,14 +26,13 @@ def _calls_rule_function_test(ctx):
 
     env = unittest.begin(ctx)
     
-
     # It should insert the first time.
     repository.maybe(_dummy_function, "foo")
-    asserts.equals(env, _existing_rules, {"foo": 1})
+    asserts.equals(env, _existing_rules, {"foo": 1}, _existing_rules)
 
     # And find a preexisting entry the second and not change it.
     repository.maybe(_dummy_function, "foo")
-    asserts.equals(env, _existing_rules, {"foo": 1})
+    asserts.equals(env, _existing_rules, {"foo": 1}, _existing_rules)
 
     unittest.end(env)
 

--- a/tests/repository_tests.bzl
+++ b/tests/repository_tests.bzl
@@ -27,12 +27,12 @@ def _calls_rule_function_test(ctx):
     env = unittest.begin(ctx)
     
     # It should insert the first time.
-    repository.maybe(_dummy_function, "foo")
-    asserts.equals(env, _existing_rules, {"foo": 1}, existing_rules = _existing_rules)
+    repository.maybe(_dummy_function, "foo", existing_rules = _existing_rules)
+    asserts.equals(env, _existing_rules, {"foo": 1})
 
     # And find a preexisting entry the second and not change it.
-    repository.maybe(_dummy_function, "foo")
-    asserts.equals(env, _existing_rules, {"foo": 1}, existing_rules = _existing_rules)
+    repository.maybe(_dummy_function, "foo", existing_rules = _existing_rules)
+    asserts.equals(env, _existing_rules, {"foo": 1})
 
     unittest.end(env)
 

--- a/tests/repository_tests.bzl
+++ b/tests/repository_tests.bzl
@@ -21,7 +21,7 @@ def _dummy_function(name):
     """Used to validate the maybe function is/isn't called."""
     _existing_rules[name] = (_existing_rules[name] or 0) + 1
 
-def _calls_rule_function(ctx):
+def _calls_rule_function_test(ctx):
     """Unit tests for repository.maybe."""
 
     env = unittest.begin(ctx)
@@ -37,11 +37,11 @@ def _calls_rule_function(ctx):
 
     unittest.end(env)
 
-calls_rule_function = unittest.make(_calls_rule_function)
+calls_rule_function_test = unittest.make(_calls_rule_function_test)
 
 def repository_test_suite():
     """Creates the test targets and test suite for repository.bzl tests."""
     unittest.suite(
         "repository_tests",
-        calls_rule_function,
+        calls_rule_function_test,
     )


### PR DESCRIPTION
This helper can be used when creating repository rules.