### PR TITLE
Update to google style

### DIFF
--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -1,9 +1,28 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing a library rule for aggregating rules files.
+
+DEPRECATED: Use bzl_library.bzl instead.
+"""
+
+load("//:bzl_library.bzl", "StarlarkLibraryInfo", "bzl_library")
+
 print(
     "WARNING: skylark_library.bzl is deprecated and will go away in the future, please" +
     " use bzl_library.bzl instead.",
 )
-
-load("//:bzl_library.bzl", "StarlarkLibraryInfo", "bzl_library")
 
 # These are temporary forwarding macros to facilitate migration to
 # the new names for these objects.

--- a/skylark_library.bzl
+++ b/skylark_library.bzl
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,8 @@
 
 """Skylib module containing a library rule for aggregating rules files.
 
-DEPRECATED: Use bzl_library.bzl instead.
+Deprecated:
+  Use bzl_library in bzl_library.bzl instead.
 """
 
 load("//:bzl_library.bzl", "StarlarkLibraryInfo", "bzl_library")


### PR DESCRIPTION
Update skylark_library.bzl to conform to Google's code style

Even though skylark_library.bzl is deprecated, it should still conform to Google's code style.