### PR TITLE
Upgrade to the new actions API

### DIFF
--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -166,10 +166,10 @@ def _end(env):
         "EOF",
         "exit %d" % len(env.failures),
     ])
-    env.ctx.file_action(
+    env.ctx.actions.write(
         output = env.ctx.outputs.executable,
         content = cmd,
-        executable = True,
+        is_executable = True,
     )
 
 def _fail(env, msg):


### PR DESCRIPTION
In future Bazel releases `ctx.file_action` will be removed.
`ctx.action.write` should be used instead.

With this change tests pass even if `--incompatible_new_actions_api`
is used.

Bazel issue:
https://github.com/bazelbuild/bazel/issues/5825