### PR TITLE
Fix example in README.md on loading from .bzl file in lib/ directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ the modules (listed [below](#list-of-modules)) and access the symbols by
 dotting into those structs:
 
 ```python
-load("@bazel_skylib//lib/paths.bzl", "paths")
-load("@bazel_skylib//lib/shell.bzl", "shell")
+load("@bazel_skylib//:lib/paths.bzl", "paths")
+load("@bazel_skylib//:lib/shell.bzl", "shell")
 
 p = paths.basename("foo.bar")
 s = shell.quote(p)


### PR DESCRIPTION
Without this change, you would run into an error:

    ERROR: error loading package '': Extension file not found. Unable to
    load package for '@bazel_skylib//lib/paths.bzl:paths.bzl': BUILD file
    not found on package path