### PR TITLE
Explicitly call to_list on depset.

### DIFF
--- a/lib/new_sets.bzl
+++ b/lib/new_sets.bzl
@@ -34,6 +34,8 @@ def _make(elements = None):
       A set containing the passed in values.
     """
     elements = elements if elements else []
+    if type(elements) == type(depset()):
+      elements = elements.to_list()
     return struct(_values = {e: None for e in elements})
 
 def _copy(s):


### PR DESCRIPTION
This is in preparation to roll out the --incompatible_depset_is_not_iterable flag.