### PR TITLE
Run buildifier --lint=fix over the files.

### DIFF
--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -52,10 +52,10 @@ def _unittest_toolchain_impl(ctx):
 unittest_toolchain = rule(
     implementation = _unittest_toolchain_impl,
     attrs = {
-        "file_ext": attr.string(mandatory = True),
-        "success_templ": attr.string(mandatory = True),
         "failure_templ": attr.string(mandatory = True),
+        "file_ext": attr.string(mandatory = True),
         "join_on": attr.string(mandatory = True),
+        "success_templ": attr.string(mandatory = True),
     },
 )
 

--- a/tests/selects_tests.bzl
+++ b/tests/selects_tests.bzl
@@ -25,30 +25,30 @@ def _with_or_test(ctx):
     # dictionary from a select().
 
     # Test select()-compatible input syntax.
-    input_dict = {":foo": ":d1", "//conditions:default": ":d1"}
+    input_dict = {"//conditions:default": ":d1", ":foo": ":d1"}
     asserts.equals(env, input_dict, selects.with_or_dict(input_dict))
 
     # Test OR syntax.
     or_dict = {(":foo", ":bar"): ":d1"}
     asserts.equals(
         env,
-        {":foo": ":d1", ":bar": ":d1"},
+        {":bar": ":d1", ":foo": ":d1"},
         selects.with_or_dict(or_dict),
     )
 
     # Test mixed syntax.
     mixed_dict = {
-        ":foo": ":d1",
-        (":bar", ":baz"): ":d2",
         "//conditions:default": ":d3",
+        (":bar", ":baz"): ":d2",
+        ":foo": ":d1",
     }
     asserts.equals(
         env,
         {
-            ":foo": ":d1",
+            "//conditions:default": ":d3",
             ":bar": ":d2",
             ":baz": ":d2",
-            "//conditions:default": ":d3",
+            ":foo": ":d1",
         },
         selects.with_or_dict(mixed_dict),
     )


### PR DESCRIPTION
Fixes some dict order issues with the current version of buildifier.