### PR TITLE
Add analysis-test test framework

### DIFF
--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -72,6 +72,7 @@ def _impl_function_name(impl):
     """Derives the name of the given rule implementation function.
 
     This can be used for better test feedback."""
+
     # Starlark currently stringifies a function as "<function NAME>", so we use
     # that knowledge to parse the "NAME" portion out. If this behavior ever
     # changes, we'll need to update this.
@@ -175,7 +176,7 @@ def _make_analysis_test(impl, expect_failure = False, config_settings = {}):
 
     if changed_settings:
         test_transition = analysis_test_transition(
-            settings = changed_settings
+            settings = changed_settings,
         )
         attrs["target_under_test"] = attr.label(cfg = test_transition, mandatory = True)
     else:
@@ -277,7 +278,8 @@ def _end(env):
     if getattr(env.ctx.attr, _IS_ANALYSIS_TEST_ATTR_NAME, False):
         return [AnalysisTestResultInfo(
             success = (len(env.failures) == 0),
-            message = "\n".join(env.failures))]
+            message = "\n".join(env.failures),
+        )]
     else:
         tc = env.ctx.toolchains[TOOLCHAIN_TYPE].unittest_toolchain_info
         testbin = env.ctx.actions.declare_file(env.ctx.label.name + tc.file_ext)

--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -407,7 +407,7 @@ def _expect_failure(env, expected_failure_msg = ""):
             actual_errors += cause.message + "\n"
         if actual_errors.find(expected_failure_msg) < 0:
             expectation_msg = "Expected errors to contain '%s' but did not. " % expected_failure_msg
-            expectation_msg += "Actual error:%s" % actual_errors
+            expectation_msg += "Actual errors:%s" % actual_errors
             _fail(env, expectation_msg)
     else:
         _fail(env, "Expected failure of target_under_test, but found success")

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -11,12 +11,7 @@ load(":sets_tests.bzl", "sets_test_suite")
 load(":shell_tests.bzl", "shell_test_suite")
 load(":structs_tests.bzl", "structs_test_suite")
 load(":types_tests.bzl", "types_test_suite")
-load(
-    ":unittest_tests.bzl",
-    "change_setting_fake_rule",
-    "change_setting_test",
-    "unittest_passing_tests_suite",
-)
+load(":unittest_tests.bzl", "unittest_passing_tests_suite")
 load(":versions_tests.bzl", "versions_test_suite")
 
 licenses(["notice"])

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -11,9 +11,12 @@ load(":sets_tests.bzl", "sets_test_suite")
 load(":shell_tests.bzl", "shell_test_suite")
 load(":structs_tests.bzl", "structs_test_suite")
 load(":types_tests.bzl", "types_test_suite")
-load(":unittest_tests.bzl",
-     "change_setting_fake_rule", "change_setting_test",
-     "unittest_passing_tests_suite")
+load(
+    ":unittest_tests.bzl",
+    "change_setting_fake_rule",
+    "change_setting_test",
+    "unittest_passing_tests_suite",
+)
 load(":versions_tests.bzl", "versions_test_suite")
 
 licenses(["notice"])
@@ -49,8 +52,8 @@ versions_test_suite()
 bzl_library(
     name = "unittest_tests_bzl",
     srcs = ["unittest_tests.bzl"],
+    visibility = ["//visibility:private"],
     deps = ["//lib:unittest"],
-    visibility = [ "//visibility:private" ],
 )
 
 sh_test(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -11,6 +11,9 @@ load(":sets_tests.bzl", "sets_test_suite")
 load(":shell_tests.bzl", "shell_test_suite")
 load(":structs_tests.bzl", "structs_test_suite")
 load(":types_tests.bzl", "types_test_suite")
+load(":unittest_tests.bzl",
+     "change_setting_fake_rule", "change_setting_test",
+     "unittest_passing_tests_suite")
 load(":versions_tests.bzl", "versions_test_suite")
 
 licenses(["notice"])
@@ -39,12 +42,15 @@ structs_test_suite()
 
 types_test_suite()
 
+unittest_passing_tests_suite()
+
 versions_test_suite()
 
 bzl_library(
-    name = "unittest_tests",
+    name = "unittest_tests_bzl",
     srcs = ["unittest_tests.bzl"],
     deps = ["//lib:unittest"],
+    visibility = [ "//visibility:private" ],
 )
 
 sh_test(
@@ -52,7 +58,7 @@ sh_test(
     srcs = ["unittest_test.sh"],
     data = [
         ":unittest.bash",
-        ":unittest_tests",
+        ":unittest_tests_bzl",
         "//toolchains/unittest:test_deps",
         "@bazel_tools//tools/bash/runfiles",
     ],

--- a/tests/unittest_test.sh
+++ b/tests/unittest_test.sh
@@ -69,11 +69,21 @@ EOF
   cat > testdir/BUILD <<EOF
 load("//tests:unittest_tests.bzl",
     "basic_passing_test",
-    "basic_failing_test")
+    "basic_failing_test",
+    "fail_unexpected_passing_test",
+    "fail_unexpected_passing_fake_rule")
 
 basic_passing_test(name = "basic_passing_test")
 
 basic_failing_test(name = "basic_failing_test")
+
+fail_unexpected_passing_test(
+    name = "fail_unexpected_passing_test",
+    target_under_test = ":fail_unexpected_passing_fake_target",
+)
+fail_unexpected_passing_fake_rule(
+    name = "fail_unexpected_passing_fake_target",
+    tags = ["manual"])
 EOF
 }
 
@@ -92,6 +102,13 @@ function test_basic_failing_test() {
       >"$TEST_log" 2>&1 || fail "Expected test to fail"
 
   expect_log "In test _basic_failing_test from //tests:unittest_tests.bzl: Expected \"1\", but got \"2\""
+}
+
+function test_fail_unexpected_passing_test() {
+  ! bazel test //testdir:fail_unexpected_passing_test --test_output=all --verbose_failures \
+      >"$TEST_log" 2>&1 || fail "Expected test to fail"
+
+  expect_log "Expected failure of target_under_test, but found success"
 }
 
 run_suite "unittest test suite"

--- a/tests/unittest_tests.bzl
+++ b/tests/unittest_tests.bzl
@@ -1,5 +1,7 @@
 load("//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 
+"""Unit tests for unittest.bzl."""
+
 ###################################
 ####### fail_basic_test ########
 ###################################

--- a/tests/unittest_tests.bzl
+++ b/tests/unittest_tests.bzl
@@ -3,7 +3,7 @@
 load("//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 
 ###################################
-####### fail_basic_test ########
+####### fail_basic_test ###########
 ###################################
 def _basic_failing_test(ctx):
     """Unit tests for a basic library verification test that fails."""

--- a/tests/unittest_tests.bzl
+++ b/tests/unittest_tests.bzl
@@ -13,7 +13,6 @@ def _basic_failing_test(ctx):
 
 basic_failing_test = unittest.make(_basic_failing_test)
 
-
 ###################################
 ####### basic_passing_test ########
 ###################################
@@ -26,7 +25,6 @@ def _basic_passing_test(ctx):
     return unittest.end(env)
 
 basic_passing_test = unittest.make(_basic_passing_test)
-
 
 ###################################
 ####### change_setting_test #######
@@ -47,14 +45,15 @@ def _change_setting_fake_rule(ctx):
 
 change_setting_fake_rule = rule(
     implementation = _change_setting_fake_rule,
-    fragments = ["cpp"])
+    fragments = ["cpp"],
+)
 
 change_setting_test = analysistest.make(
     _change_setting_test,
     config_settings = {
-        "//command_line_option:minimum_os_version" : "1234.5678"
-    })
-
+        "//command_line_option:minimum_os_version": "1234.5678",
+    },
+)
 
 ####################################
 ####### failure_testing_test #######
@@ -71,12 +70,13 @@ def _failure_testing_fake_rule(ctx):
     fail("This rule should never work")
 
 failure_testing_fake_rule = rule(
-    implementation = _failure_testing_fake_rule)
+    implementation = _failure_testing_fake_rule,
+)
 
 failure_testing_test = analysistest.make(
     _failure_testing_test,
-    expect_failure = True)
-
+    expect_failure = True,
+)
 
 ############################################
 ####### fail_unexpected_passing_test #######
@@ -93,12 +93,13 @@ def _fail_unexpected_passing_fake_rule(ctx):
     return []
 
 fail_unexpected_passing_fake_rule = rule(
-    implementation = _fail_unexpected_passing_fake_rule)
+    implementation = _fail_unexpected_passing_fake_rule,
+)
 
 fail_unexpected_passing_test = analysistest.make(
     _fail_unexpected_passing_test,
-    expect_failure = True)
-
+    expect_failure = True,
+)
 
 ################################################
 ####### change_setting_with_failure_test #######
@@ -118,15 +119,16 @@ def _change_setting_with_failure_fake_rule(ctx):
 
 change_setting_with_failure_fake_rule = rule(
     implementation = _change_setting_with_failure_fake_rule,
-    fragments = ["cpp"])
+    fragments = ["cpp"],
+)
 
 change_setting_with_failure_test = analysistest.make(
     _change_setting_with_failure_test,
     expect_failure = True,
     config_settings = {
-        "//command_line_option:minimum_os_version" : "error_error"
-    })
-
+        "//command_line_option:minimum_os_version": "error_error",
+    },
+)
 
 #########################################
 
@@ -147,7 +149,8 @@ def unittest_passing_tests_suite():
     )
     change_setting_fake_rule(
         name = "change_setting_fake_target",
-        tags = ["manual"])
+        tags = ["manual"],
+    )
 
     failure_testing_test(
         name = "failure_testing_test",
@@ -155,7 +158,8 @@ def unittest_passing_tests_suite():
     )
     failure_testing_fake_rule(
         name = "failure_testing_fake_target",
-        tags = ["manual"])
+        tags = ["manual"],
+    )
 
     change_setting_with_failure_test(
         name = "change_setting_with_failure_test",
@@ -163,7 +167,5 @@ def unittest_passing_tests_suite():
     )
     change_setting_with_failure_fake_rule(
         name = "change_setting_with_failure_fake_target",
-        tags = ["manual"])
-
-
-
+        tags = ["manual"],
+    )

--- a/tests/unittest_tests.bzl
+++ b/tests/unittest_tests.bzl
@@ -1,5 +1,22 @@
-load("//lib:unittest.bzl", "asserts", "unittest")
+load("//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 
+###################################
+####### fail_basic_test ########
+###################################
+def _basic_failing_test(ctx):
+    """Unit tests for a basic library verification test that fails."""
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, 1, 2)
+
+    return unittest.end(env)
+
+basic_failing_test = unittest.make(_basic_failing_test)
+
+
+###################################
+####### basic_passing_test ########
+###################################
 def _basic_passing_test(ctx):
     """Unit tests for a basic library verification test."""
     env = unittest.begin(ctx)
@@ -10,12 +27,143 @@ def _basic_passing_test(ctx):
 
 basic_passing_test = unittest.make(_basic_passing_test)
 
-def _basic_failing_test(ctx):
-    """Unit tests for a basic library verification test that fails."""
-    env = unittest.begin(ctx)
 
-    asserts.equals(env, 1, 2)
+###################################
+####### change_setting_test #######
+###################################
+def _change_setting_test(ctx):
+    """Test to verify that an analysis test may change configuration."""
+    env = analysistest.begin(ctx)
 
-    return unittest.end(env)
+    dep_min_os_version = ctx.attr.target_under_test[0][_ChangeSettingInfo].min_os_version
+    asserts.equals(env, "1234.5678", dep_min_os_version)
 
-basic_failing_test = unittest.make(_basic_failing_test)
+    return analysistest.end(env)
+
+_ChangeSettingInfo = provider()
+
+def _change_setting_fake_rule(ctx):
+    return [_ChangeSettingInfo(min_os_version = ctx.fragments.cpp.minimum_os_version())]
+
+change_setting_fake_rule = rule(
+    implementation = _change_setting_fake_rule,
+    fragments = ["cpp"])
+
+change_setting_test = analysistest.make(
+    _change_setting_test,
+    config_settings = {
+        "//command_line_option:minimum_os_version" : "1234.5678"
+    })
+
+
+####################################
+####### failure_testing_test #######
+####################################
+def _failure_testing_test(ctx):
+    """Test to verify that an analysis test may verify a rule fails with fail()."""
+    env = analysistest.begin(ctx)
+
+    asserts.expect_failure(env, "This rule should never work")
+
+    return analysistest.end(env)
+
+def _failure_testing_fake_rule(ctx):
+    fail("This rule should never work")
+
+failure_testing_fake_rule = rule(
+    implementation = _failure_testing_fake_rule)
+
+failure_testing_test = analysistest.make(
+    _failure_testing_test,
+    expect_failure = True)
+
+
+############################################
+####### fail_unexpected_passing_test #######
+############################################
+def _fail_unexpected_passing_test(ctx):
+    """Test that fails by expecting an error that never occurs."""
+    env = analysistest.begin(ctx)
+
+    asserts.expect_failure(env, "Oh no, going to fail")
+
+    return analysistest.end(env)
+
+def _fail_unexpected_passing_fake_rule(ctx):
+    return []
+
+fail_unexpected_passing_fake_rule = rule(
+    implementation = _fail_unexpected_passing_fake_rule)
+
+fail_unexpected_passing_test = analysistest.make(
+    _fail_unexpected_passing_test,
+    expect_failure = True)
+
+
+################################################
+####### change_setting_with_failure_test #######
+################################################
+def _change_setting_with_failure_test(ctx):
+    """Test verifying failure while changing configuration."""
+    env = analysistest.begin(ctx)
+
+    asserts.expect_failure(env, "unexpected minimum_os_version!!!")
+
+    return analysistest.end(env)
+
+def _change_setting_with_failure_fake_rule(ctx):
+    if ctx.fragments.cpp.minimum_os_version() == "error_error":
+        fail("unexpected minimum_os_version!!!")
+    return []
+
+change_setting_with_failure_fake_rule = rule(
+    implementation = _change_setting_with_failure_fake_rule,
+    fragments = ["cpp"])
+
+change_setting_with_failure_test = analysistest.make(
+    _change_setting_with_failure_test,
+    expect_failure = True,
+    config_settings = {
+        "//command_line_option:minimum_os_version" : "error_error"
+    })
+
+
+#########################################
+
+def unittest_passing_tests_suite():
+    """Creates the test targets and test suite for passing unittest.bzl tests.
+
+    Not all tests are included. Some unittest.bzl tests verify a test fails
+    when assertions are not met. Such tests must be run in an e2e shell test.
+    This suite only includes tests which verify success tests."""
+    unittest.suite(
+        "unittest_tests",
+        basic_passing_test,
+    )
+
+    change_setting_test(
+        name = "change_setting_test",
+        target_under_test = ":change_setting_fake_target",
+    )
+    change_setting_fake_rule(
+        name = "change_setting_fake_target",
+        tags = ["manual"])
+
+    failure_testing_test(
+        name = "failure_testing_test",
+        target_under_test = ":failure_testing_fake_target",
+    )
+    failure_testing_fake_rule(
+        name = "failure_testing_fake_target",
+        tags = ["manual"])
+
+    change_setting_with_failure_test(
+        name = "change_setting_with_failure_test",
+        target_under_test = ":change_setting_with_failure_fake_target",
+    )
+    change_setting_with_failure_fake_rule(
+        name = "change_setting_with_failure_fake_target",
+        tags = ["manual"])
+
+
+

--- a/tests/unittest_tests.bzl
+++ b/tests/unittest_tests.bzl
@@ -1,6 +1,6 @@
-load("//lib:unittest.bzl", "analysistest", "asserts", "unittest")
-
 """Unit tests for unittest.bzl."""
+
+load("//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 
 ###################################
 ####### fail_basic_test ########


### PR DESCRIPTION
This framework allows for easy creation of unittest-like tests to make assertions
on the provider-values returned by real targets.

Extensive documentation (in the form of updating the repository README) to follow in a future PR