### PR TITLE
Fix Buildifier version

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -108,4 +108,4 @@ tasks:
     - "-//tests:analysis_test_e2e_test"
     - "-//tests:unittest_e2e_test"
 
-buildifier: true
+buildifier: latest


### PR DESCRIPTION
"buildifier: true" has been deprecated by https://github.com/bazelbuild/continuous-integration/pull/542