### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ your workspace. Replace the version number in the `tag` attribute with the
 version you wish to depend on:
 
 ```python
-git_repository(
+# bazel-skylb 0.8.0 released 2019.03.20 (https://github.com/bazelbuild/bazel-skylib/releases/tag/0.8.0)
+skylib_version = "0.8.0"
+http_archive(
     name = "bazel_skylib",
-    remote = "https://github.com/bazelbuild/bazel-skylib.git",
-    tag = "0.1.0",  # change this to use a different release
+    type = "tar.gz",
+    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib.{}.tar.gz".format (skylib_version, skylib_version),
+    sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
 )
 ```
 


### PR DESCRIPTION
The README is referring to the deprecated git_repository() rule, which
causes in Bazel 0.22.