### PR TITLE
Reformat with buildifier --warnings=all

### DIFF
--- a/rules/private/write_file_private.bzl
+++ b/rules/private/write_file_private.bzl
@@ -39,8 +39,8 @@ def _ximpl(ctx):
     return _common_impl(ctx, True)
 
 _ATTRS = {
-    "content": attr.string_list(mandatory = False, allow_empty = True),
     "out": attr.output(mandatory = True),
+    "content": attr.string_list(mandatory = False, allow_empty = True),
 }
 
 _write_file = rule(

--- a/tests/selects_tests.bzl
+++ b/tests/selects_tests.bzl
@@ -25,7 +25,7 @@ def _with_or_test(ctx):
     # dictionary from a select().
 
     # Test select()-compatible input syntax.
-    input_dict = {"//conditions:default": ":d1", ":foo": ":d1"}
+    input_dict = {":foo": ":d1", "//conditions:default": ":d1"}
     asserts.equals(env, input_dict, selects.with_or_dict(input_dict))
 
     # Test OR syntax.
@@ -38,17 +38,17 @@ def _with_or_test(ctx):
 
     # Test mixed syntax.
     mixed_dict = {
-        "//conditions:default": ":d3",
-        (":bar", ":baz"): ":d2",
         ":foo": ":d1",
+        (":bar", ":baz"): ":d2",
+        "//conditions:default": ":d3",
     }
     asserts.equals(
         env,
         {
-            "//conditions:default": ":d3",
             ":bar": ":d2",
             ":baz": ":d2",
             ":foo": ":d1",
+            "//conditions:default": ":d3",
         },
         selects.with_or_dict(mixed_dict),
     )


### PR DESCRIPTION
Fixes some dictionaries to put things in the more common orders. Buildifer
used to default to doing this check and reformatting which is why the
//conditions:default got moved up in these in the first place.
