### PR TITLE
write_file: support different line endings

### DIFF
--- a/docs/write_file_doc.md
+++ b/docs/write_file_doc.md
@@ -1,7 +1,7 @@
 ## write_file
 
 <pre>
-write_file(<a href="#write_file-name">name</a>, <a href="#write_file-out">out</a>, <a href="#write_file-content">content</a>, <a href="#write_file-is_executable">is_executable</a>, <a href="#write_file-kwargs">kwargs</a>)
+write_file(<a href="#write_file-name">name</a>, <a href="#write_file-out">out</a>, <a href="#write_file-content">content</a>, <a href="#write_file-is_executable">is_executable</a>, <a href="#write_file-newline">newline</a>, <a href="#write_file-kwargs">kwargs</a>)
 </pre>
 
 Creates a UTF-8 encoded text file.
@@ -47,9 +47,21 @@ Creates a UTF-8 encoded text file.
       <td>
         optional. default is <code>False</code>
         <p>
-          A boolean. Whether to make the output file executable. When
-    True, the rule's output can be executed using `bazel run` and can be
-    in the srcs of binary and test rules that require executable sources.
+          A boolean. Whether to make the output file executable.
+    When True, the rule's output can be executed using `bazel run` and can
+    be in the srcs of binary and test rules that require executable
+    sources.
+        </p>
+      </td>
+    </tr>
+    <tr id="write_file-newline">
+      <td><code>newline</code></td>
+      <td>
+        optional. default is <code>None</code>
+        <p>
+          one of ["auto", "unix", "windows"], default is "auto": line
+    endings to use. "auto" for platform-determined, "unix" for LF and
+    "windows" for CRLF.
         </p>
       </td>
     </tr>

--- a/docs/write_file_doc.md
+++ b/docs/write_file_doc.md
@@ -57,11 +57,10 @@ Creates a UTF-8 encoded text file.
     <tr id="write_file-newline">
       <td><code>newline</code></td>
       <td>
-        optional. default is <code>None</code>
+        optional. default is <code>"auto"</code>
         <p>
-          one of ["auto", "unix", "windows"], default is "auto": line
-    endings to use. "auto" for platform-determined, "unix" for LF and
-    "windows" for CRLF.
+          one of ["auto", "unix", "windows"]: line endings to use. "auto"
+    for platform-determined, "unix" for LF, and "windows" for CRLF.
         </p>
       </td>
     </tr>
@@ -70,7 +69,7 @@ Creates a UTF-8 encoded text file.
       <td>
         optional.
         <p>
-          further keyword arguments, e.g. `visibility`
+          further keyword arguments, e.g. <code>visibility</code>
         </p>
       </td>
     </tr>

--- a/rules/private/write_file_private.bzl
+++ b/rules/private/write_file_private.bzl
@@ -70,7 +70,7 @@ def write_file(
         out,
         content = [],
         is_executable = False,
-        newline = None,
+        newline = "auto",
         **kwargs):
     """Creates a UTF-8 encoded text file.
 
@@ -83,10 +83,9 @@ def write_file(
           When True, the rule's output can be executed using `bazel run` and can
           be in the srcs of binary and test rules that require executable
           sources.
-      newline: one of ["auto", "unix", "windows"], default is "auto": line
-          endings to use. "auto" for platform-determined, "unix" for LF and
-          "windows" for CRLF.
-      **kwargs: further keyword arguments, e.g. `visibility`
+      newline: one of ["auto", "unix", "windows"]: line endings to use. "auto"
+          for platform-determined, "unix" for LF, and "windows" for CRLF.
+      **kwargs: further keyword arguments, e.g. <code>visibility</code>
     """
     if is_executable:
         _write_xfile(

--- a/tests/write_file/BUILD
+++ b/tests/write_file/BUILD
@@ -122,8 +122,12 @@ write_file(
 write_file(
     name = "newline_unix_actual",
     out = "out/newline_unix_actual.txt",
+    content = [
+        "ab",
+        "cd",
+        "ef",
+    ],
     newline = "unix",
-    content = ["ab", "cd", "ef"],
 )
 
 write_file(
@@ -141,8 +145,12 @@ diff_test(
 write_file(
     name = "newline_win_actual",
     out = "out/newline_win_actual.txt",
+    content = [
+        "ab",
+        "cd",
+        "ef",
+    ],
     newline = "windows",
-    content = ["ab", "cd", "ef"],
 )
 
 write_file(

--- a/tests/write_file/BUILD
+++ b/tests/write_file/BUILD
@@ -32,6 +32,7 @@
 #   field of it, so we assert that that field contains the output file of the
 #   rule
 
+load("//rules:diff_test.bzl", "diff_test")
 load("//rules:write_file.bzl", "write_file")
 
 licenses(["notice"])
@@ -116,4 +117,42 @@ write_file(
         "echo potato",
     ],
     is_executable = True,
+)
+
+write_file(
+    name = "newline_unix_actual",
+    out = "out/newline_unix_actual.txt",
+    newline = "unix",
+    content = ["ab", "cd", "ef"],
+)
+
+write_file(
+    name = "newline_unix_exp",
+    out = "out/newline_unix_exp.txt",
+    content = ["ab\ncd\nef"],
+)
+
+diff_test(
+    name = "unix_line_ending_test",
+    file1 = ":newline_unix_actual",
+    file2 = ":newline_unix_exp",
+)
+
+write_file(
+    name = "newline_win_actual",
+    out = "out/newline_win_actual.txt",
+    newline = "windows",
+    content = ["ab", "cd", "ef"],
+)
+
+write_file(
+    name = "newline_win_exp",
+    out = "out/newline_win_exp.txt",
+    content = ["ab\r\ncd\r\nef"],
+)
+
+diff_test(
+    name = "win_line_ending_test",
+    file1 = ":newline_win_actual",
+    file2 = ":newline_win_exp",
 )


### PR DESCRIPTION
The user can specify which line endings they want
write_file to use. This helps avoiding line ending
mismatches with diff_test.

Example: diff_test verifies that a rule generates
correct output by comparing it to a checked-in
"golden" file. Both files are text files, and the
user builds on Windows but the golden file was
written on Linux and git checkout preserved
original line endings.

Without explicitly specifying which line endings
to use, this diff_test would fail on an otherwise
good output.

With explicit line endings we don't need to check
in the golden file to git, we can just generate it
with "auto" line endings.