### PR TITLE
Fix for --incompatible_no_support_tools_in_action_inputs on Windows

### DIFF
--- a/rules/private/copy_file_private.bzl
+++ b/rules/private/copy_file_private.bzl
@@ -37,7 +37,8 @@ def copy_cmd(ctx, src, dst):
         is_executable = True,
     )
     ctx.actions.run(
-        inputs = [src, bat],
+        inputs = [src],
+        tools = [bat],
         outputs = [dst],
         executable = "cmd.exe",
         arguments = ["/C", bat.path.replace("/", "\\")],


### PR DESCRIPTION
Error identified with Bazel CI: https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/120#4bcecf1f-c7d3-4de2-ba63-1ea125faa54e