### PR TITLE
Make sets.bzl point to new_sets.bzl instead of old_sets.bzl

### DIFF
--- a/lib/sets.bzl
+++ b/lib/sets.bzl
@@ -14,6 +14,6 @@
 
 """Skylib module reexporting deprecated set algorithms."""
 
-load(":old_sets.bzl", _sets = "sets")
+load(":new_sets.bzl", _sets = "sets")
 
 sets = _sets

--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -20,7 +20,7 @@ assertions used to within tests.
 """
 
 load(":new_sets.bzl", new_sets = "sets")
-load(":sets.bzl", "sets")
+load(":old_sets.bzl", "sets")
 load(":types.bzl", "types")
 
 # The following function should only be called from WORKSPACE files and workspace macros.

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -3,11 +3,11 @@ load(":build_test_tests.bzl", "build_test_test_suite")
 load(":collections_tests.bzl", "collections_test_suite")
 load(":dicts_tests.bzl", "dicts_test_suite")
 load(":maprule_tests.bzl", "maprule_test_suite")
+load(":old_sets_tests.bzl", "old_sets_test_suite")
 load(":new_sets_tests.bzl", "new_sets_test_suite")
 load(":partial_tests.bzl", "partial_test_suite")
 load(":paths_tests.bzl", "paths_test_suite")
 load(":selects_tests.bzl", "selects_test_suite")
-load(":sets_tests.bzl", "sets_test_suite")
 load(":shell_tests.bzl", "shell_args_test_gen", "shell_test_suite")
 load(":structs_tests.bzl", "structs_test_suite")
 load(":types_tests.bzl", "types_test_suite")
@@ -29,15 +29,15 @@ dicts_test_suite()
 
 maprule_test_suite()
 
+old_sets_test_suite()
+
+new_sets_test_suite()
+
 partial_test_suite()
 
 paths_test_suite()
 
 selects_test_suite()
-
-sets_test_suite()
-
-new_sets_test_suite()
 
 shell_test_suite()
 

--- a/tests/old_sets_tests.bzl
+++ b/tests/old_sets_tests.bzl
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for sets.bzl."""
+"""Unit tests for old_sets.bzl."""
 
-load("//lib:sets.bzl", "sets")
+load("//lib:old_sets.bzl", "sets")
 load("//lib:unittest.bzl", "asserts", "unittest")
 
 def _is_equal_test(ctx):
@@ -140,10 +140,10 @@ def _difference_test(ctx):
 
 difference_test = unittest.make(_difference_test)
 
-def sets_test_suite():
-    """Creates the test targets and test suite for sets.bzl tests."""
+def old_sets_test_suite():
+    """Creates the test targets and test suite for old_sets.bzl tests."""
     unittest.suite(
-        "sets_tests",
+        "old_sets_tests",
         disjoint_test,
         intersection_test,
         is_equal_test,


### PR DESCRIPTION
Make sets.bzl point to new_sets.bzl instead of old_sets.bzl

new_sets.bzl and old_sets.bzl should be removed in the following skylib release.

Fixes #155.