### PR TITLE
Make config_setting_group visibility aware

### DIFF
--- a/lib/selects.bzl
+++ b/lib/selects.bzl
@@ -107,7 +107,7 @@ def _config_setting_group(name, match_any = [], match_all = [], visibility = Non
       match_all: A list of `config_settings`. This group matches if *every*
           member in the list matches. If this is set, `match_any` must be not
           set.
-      visibility: Visibiliity of the main alias used.
+      visibility: Visibility of the config_setting_group.
     """
     empty1 = not bool(len(match_any))
     empty2 = not bool(len(match_all))


### PR DESCRIPTION
There might be other attributes of config_setting you want to expose. I didn't want to do a general kwargs since this is using alias underneath and that might allow leaking attributes you don't want the macro to support.