### PR TITLE
Comply with the standards of the Bazel federation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,22 +1,30 @@
 workspace(name = "bazel_skylib")
 
-load(":workspace.bzl", "bazel_skylib_workspace")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_federation",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/130c84ec6d60f31b711400e8445a8d0d4a2b5de8.zip",
+    sha256 = "9d4fdf7cc533af0b50f7dd8e58bea85df3b4454b7ae00056d7090eb98e3515cc",
+    strip_prefix = "bazel-federation-130c84ec6d60f31b711400e8445a8d0d4a2b5de8",
+    type = "zip",
+)
 
-bazel_skylib_workspace()
+load("@bazel_federation//:repositories.bzl", "bazel_skylib_deps")
+
+bazel_skylib_deps()
+
+load("@bazel_federation//setup:bazel_skylib.bzl", "bazel_skylib_setup")
+
+bazel_skylib_setup()
 
 # Below this line is for documentation generation only,
 # and should thus not be included by dependencies on
 # bazel-skylib.
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//:internal_deps.bzl", "bazel_skylib_internal_deps")
 
-http_archive(
-    name = "io_bazel_skydoc",
-    url = "https://github.com/bazelbuild/skydoc/archive/0.3.0.tar.gz",
-    sha256 = "c2d66a0cc7e25d857e480409a8004fdf09072a1bd564d6824441ab2f96448eea",
-    strip_prefix = "skydoc-0.3.0",
-)
+bazel_skylib_internal_deps()
 
-load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
+load("//:internal_setup.bzl", "bazel_skylib_internal_setup")
 
-skydoc_repositories()
+bazel_skylib_internal_setup()

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -1,0 +1,6 @@
+load("@bazel_federation//:repositories.bzl", "bazel", "bazel_stardoc")
+
+def bazel_skylib_internal_deps():
+    bazel()
+    bazel_stardoc()
+

--- a/internal_deps.bzl
+++ b/internal_deps.bzl
@@ -1,6 +1,21 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dependencies that are needed for running skylib tests."""
+
 load("@bazel_federation//:repositories.bzl", "bazel", "bazel_stardoc")
 
 def bazel_skylib_internal_deps():
     bazel()
     bazel_stardoc()
-

--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -1,0 +1,2 @@
+def bazel_skylib_internal_setup():
+    pass # placeholder function for the federation

--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -1,2 +1,18 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Setup function that must be invoked before running skylib tests."""
+
 def bazel_skylib_internal_setup():
     pass # placeholder function for the federation


### PR DESCRIPTION
This commit allows bazel_skylib to be a member of the Bazel federation, since it adds the required bzl files related to setup and dependencies.
Moreover, it also changes the WORKSPACE to fetch all dependencies through the federation.