### PR TITLE
load rules thorugh maybe so we can simultaneous updates

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,10 +6,10 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 maybe(
     http_archive,
     name = "bazel_federation",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/130c84ec6d60f31b711400e8445a8d0d4a2b5de8.zip",
     sha256 = "9d4fdf7cc533af0b50f7dd8e58bea85df3b4454b7ae00056d7090eb98e3515cc",
     strip_prefix = "bazel-federation-130c84ec6d60f31b711400e8445a8d0d4a2b5de8",
     type = "zip",
+    url = "https://github.com/bazelbuild/bazel-federation/archive/130c84ec6d60f31b711400e8445a8d0d4a2b5de8.zip",
 )
 
 load("@bazel_federation//:repositories.bzl", "bazel_skylib_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,10 @@
 workspace(name = "bazel_skylib")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+maybe(
+    http_archive,
     name = "bazel_federation",
     url = "https://github.com/bazelbuild/bazel-federation/archive/130c84ec6d60f31b711400e8445a8d0d4a2b5de8.zip",
     sha256 = "9d4fdf7cc533af0b50f7dd8e58bea85df3b4454b7ae00056d7090eb98e3515cc",
@@ -29,7 +32,8 @@ load("//:internal_setup.bzl", "bazel_skylib_internal_setup")
 
 bazel_skylib_internal_setup()
 
-http_archive(
+maybe(
+    http_archive,
     name = "rules_cc",
     sha256 = "b4b2a2078bdb7b8328d843e8de07d7c13c80e6c89e86a09d6c4b424cfd1aaa19",
     strip_prefix = "rules_cc-cb2dfba6746bfa3c3705185981f3109f0ae1b893",
@@ -38,4 +42,3 @@ http_archive(
         "https://github.com/bazelbuild/rules_cc/archive/cb2dfba6746bfa3c3705185981f3109f0ae1b893.zip",
     ],
 )
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 maybe(
-    http_archive,
+    repo_rule = http_archive,
     name = "bazel_federation",
     sha256 = "9d4fdf7cc533af0b50f7dd8e58bea85df3b4454b7ae00056d7090eb98e3515cc",
     strip_prefix = "bazel-federation-130c84ec6d60f31b711400e8445a8d0d4a2b5de8",
@@ -33,7 +33,7 @@ load("//:internal_setup.bzl", "bazel_skylib_internal_setup")
 bazel_skylib_internal_setup()
 
 maybe(
-    http_archive,
+    repo_rule = http_archive,
     name = "rules_cc",
     sha256 = "b4b2a2078bdb7b8328d843e8de07d7c13c80e6c89e86a09d6c4b424cfd1aaa19",
     strip_prefix = "rules_cc-cb2dfba6746bfa3c3705185981f3109f0ae1b893",


### PR DESCRIPTION
We need to use maybe() for federation, so we can try updates to the federation that impact how skylib loads.  All mutually recursive repos should use maybe to make this possible.