### PR TITLE
Fix distribution so that we get the right dependencies load

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,10 +6,8 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 maybe(
     repo_rule = http_archive,
     name = "bazel_federation",
-    sha256 = "9d4fdf7cc533af0b50f7dd8e58bea85df3b4454b7ae00056d7090eb98e3515cc",
-    strip_prefix = "bazel-federation-130c84ec6d60f31b711400e8445a8d0d4a2b5de8",
-    type = "zip",
-    url = "https://github.com/bazelbuild/bazel-federation/archive/130c84ec6d60f31b711400e8445a8d0d4a2b5de8.zip",
+    url = "https://github.com/bazelbuild/bazel-federation/releases/download/0.0.1/bazel_federation-0.0.1.tar.gz",
+    sha256 = "506dfbfd74ade486ac077113f48d16835fdf6e343e1d4741552b450cfc2efb53",
 )
 
 load("@bazel_federation//:repositories.bzl", "bazel_skylib_deps")

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -26,4 +26,6 @@ print_rel_notes(
     outs = ["relnotes.txt"],
     repo = "bazel-skylib",
     version = version,
+    setup_file = ":workspace.bzl",
+    deps_method = "bazel_skylib_workspace",
 )


### PR DESCRIPTION
Part of #198 
The complete fix is would require bazel-skylib -> @bazel_skylib remapping 
- to wait for https://github.com/bazelbuild/rules_pkg/pull/99 to work its way into the next rules_pkg release
- then wait for that to make it to a federation release
- then update to that federation release