### PR TITLE
Fix execute bit on empty_test.sh

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -65,3 +65,10 @@ filegroup(
         "//toolchains/unittest:distribution",
     ] + glob(["*.bzl"]),
 )
+
+filegroup(
+    name = "bins",
+    srcs = [
+        "//rules:bins",
+    ],
+)

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -6,27 +6,44 @@ load("@bazel_skylib//:version.bzl", "version")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
 
-# Build the artifact to put on the github release page.
 pkg_tar(
-    name = "bazel-skylib-%s" % version,
-    srcs = [
-        "//:distribution",
-    ],
-    extension = "tar.gz",
-    # It is all source code, so make it read-only, but since there are
-    # shell scripts, 555 is a convient choice.
+    name = "srcs",
+    srcs = ["//:distribution"],
+    mode = "0444",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    package_dir = "",
+    strip_prefix = ".",
+)
+
+pkg_tar(
+    name = "bins",
+    srcs = ["//:bins"],
     mode = "0555",
     # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",
-    package_dir = ".",
+    package_dir = "",
     strip_prefix = ".",
+)
+
+# Build the artifact to put on the github release page.
+pkg_tar(
+    name = "bazel-skylib-%s" % version,
+    extension = "tar.gz",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    strip_prefix = ".",
+    deps = [
+        ":bins.tar",
+        ":srcs.tar",
+    ],
 )
 
 print_rel_notes(
     name = "relnotes",
     outs = ["relnotes.txt"],
-    repo = "bazel-skylib",
-    version = version,
-    setup_file = ":workspace.bzl",
     deps_method = "bazel_skylib_workspace",
+    repo = "bazel-skylib",
+    setup_file = ":workspace.bzl",
+    version = version,
 )

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -13,8 +13,9 @@ pkg_tar(
         "//:distribution",
     ],
     extension = "tar.gz",
-    # It is all source code, so make it read-only.
-    mode = "0444",
+    # It is all source code, so make it read-only, but since there are
+    # shell scripts, 555 is a convient choice.
+    mode = "0555",
     # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",
     package_dir = ".",

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -60,7 +60,17 @@ filegroup(
 # The files needed for distribution
 filegroup(
     name = "distribution",
-    srcs = glob(["*"]),
+    srcs = [
+        "BUILD",
+    ] + glob(["*.bzl"]),
+    visibility = [
+        "//:__pkg__",
+    ],
+)
+
+filegroup(
+    name = "bins",
+    srcs = glob(["*.sh"]),
     visibility = [
         "//:__pkg__",
     ],


### PR DESCRIPTION
This is super ugly, but it gets the permissions right

diff /tmp/tar.1 /tmp/tar.2
1a2,3
> drwxr-xr-x 0/0               0 1999-12-31 19:00 ./rules/
> -r-xr-xr-x 0/0             103 1999-12-31 19:00 ./rules/empty_test.sh
3c5
< -r--r--r-- 0/0            1514 1999-12-31 19:00 ./BUILD
---
> -r--r--r-- 0/0            1591 1999-12-31 19:00 ./BUILD
19c21
< -r--r--r-- 0/0           18109 1999-12-31 19:00 ./lib/unittest.bzl
---
> -r--r--r-- 0/0           17682 1999-12-31 19:00 ./lib/unittest.bzl
21,22c23
< drwxr-xr-x 0/0               0 1999-12-31 19:00 ./rules/
< -r--r--r-- 0/0            1309 1999-12-31 19:00 ./rules/BUILD
---
> -r--r--r-- 0/0            1448 1999-12-31 19:00 ./rules/BUILD
28d28
< -r--r--r-- 0/0             103 1999-12-31 19:00 ./rules/empty_test.sh
