### PR TITLE
Add a toolchain for Unix shell commands

### DIFF
--- a/internal_setup.bzl
+++ b/internal_setup.bzl
@@ -14,5 +14,7 @@
 
 """Setup function that must be invoked before running skylib tests."""
 
+load("//lib:unix.bzl", "unix_configure")
+
 def bazel_skylib_internal_setup():
-    pass # placeholder function for the federation
+    unix_configure()  # Configure the Unix toolchain for unix.bzl tests.

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -71,6 +71,14 @@ bzl_library(
 )
 
 bzl_library(
+    name = "unix",
+    srcs = ["unix.bzl"],
+    deps = [
+        ":paths",
+    ],
+)
+
+bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],
 )

--- a/lib/unix.bzl
+++ b/lib/unix.bzl
@@ -1,0 +1,326 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unix shell commands toolchain support.
+
+Defines a toolchain capturing common Unix shell commands, see `unix_toolchain`,
+and `unix_configure` to scan the local environment for shell commands. The list
+of known commands is available in `unix.commands`.
+
+"""
+
+load("@bazel_tools//tools/cpp:lib_cc_configure.bzl", "get_cpu_value")
+load(":paths.bzl", "paths")
+
+# List of Unix commands as specified by IEEE Std 1003.1-2008.
+# Extracted from https://en.wikipedia.org/wiki/List_of_Unix_commands.
+_commands = [
+    "admin",
+    "alias",
+    "ar",
+    "asa",
+    "at",
+    "awk",
+    "basename",
+    "batch",
+    "bc",
+    "bg",
+    "cc",
+    "c99",
+    "cal",
+    "cat",
+    "cd",
+    "cflow",
+    "chgrp",
+    "chmod",
+    "chown",
+    "cksum",
+    "cmp",
+    "comm",
+    "command",
+    "compress",
+    "cp",
+    "crontab",
+    "csplit",
+    "ctags",
+    "cut",
+    "cxref",
+    "date",
+    "dd",
+    "delta",
+    "df",
+    "diff",
+    "dirname",
+    "du",
+    "echo",
+    "ed",
+    "env",
+    "ex",
+    "expand",
+    "expr",
+    "false",
+    "fc",
+    "fg",
+    "file",
+    "find",
+    "fold",
+    "fort77",
+    "fuser",
+    "gencat",
+    "get",
+    "getconf",
+    "getopts",
+    "grep",
+    "hash",
+    "head",
+    "iconv",
+    "id",
+    "ipcrm",
+    "ipcs",
+    "jobs",
+    "join",
+    "kill",
+    "lex",
+    "link",
+    "ln",
+    "locale",
+    "localedef",
+    "logger",
+    "logname",
+    "lp",
+    "ls",
+    "m4",
+    "mailx",
+    "make",
+    "man",
+    "mesg",
+    "mkdir",
+    "mkfifo",
+    "more",
+    "mv",
+    "newgrp",
+    "nice",
+    "nl",
+    "nm",
+    "nohup",
+    "od",
+    "paste",
+    "patch",
+    "pathchk",
+    "pax",
+    "pr",
+    "printf",
+    "prs",
+    "ps",
+    "pwd",
+    "qalter",
+    "qdel",
+    "qhold",
+    "qmove",
+    "qmsg",
+    "qrerun",
+    "qrls",
+    "qselect",
+    "qsig",
+    "qstat",
+    "qsub",
+    "read",
+    "renice",
+    "rm",
+    "rmdel",
+    "rmdir",
+    "sact",
+    "sccs",
+    "sed",
+    "sh",
+    "sleep",
+    "sort",
+    "split",
+    "strings",
+    "strip",
+    "stty",
+    "tabs",
+    "tail",
+    "talk",
+    "tee",
+    "test",
+    "time",
+    "touch",
+    "tput",
+    "tr",
+    "true",
+    "tsort",
+    "tty",
+    "type",
+    "ulimit",
+    "umask",
+    "unalias",
+    "uname",
+    "uncompress",
+    "unexpand",
+    "unget",
+    "uniq",
+    "unlink",
+    "uucp",
+    "uudecode",
+    "uuencode",
+    "uustat",
+    "uux",
+    "val",
+    "vi",
+    "wait",
+    "wc",
+    "what",
+    "who",
+    "write",
+    "xargs",
+    "yacc",
+    "zcat",
+]
+
+TOOLCHAIN_TYPE = "@bazel_skylib//toolchains/unix:toolchain_type"
+MAKE_VARIABLES = "@bazel_skylib//toolchains/unix:make_variables"
+
+def _unix_toolchain_impl(ctx):
+    commands = {}
+    for cmd in _commands:
+        cmd_path = getattr(ctx.attr, cmd, None)
+        if not cmd_path:
+            cmd_path = None
+        commands[cmd] = cmd_path
+    cmd_paths = {
+        paths.dirname(cmd_path): None
+        for cmd_path in commands.values()
+        if cmd_path
+    }.keys()
+    return [platform_common.ToolchainInfo(
+        commands = commands,
+        paths = cmd_paths,
+    )]
+
+unix_toolchain = rule(
+    attrs = {
+        cmd: attr.string(
+            doc = "Absolute path to the {} command.".format(cmd),
+            mandatory = False,
+        )
+        for cmd in _commands
+    },
+    doc = """
+A toolchain capturing standard Unix shell commands.
+
+Provides:
+  commands: Dict of String, an item per command holding the path to the executable or None.
+  paths: List of String, deduplicated bindir paths. Suitable for generating `$PATH`.
+
+Use `unix_configure` to create an instance of this toolchain.
+See `unix_make_variables` on how to use this toolchain in genrules.
+""",
+    implementation = _unix_toolchain_impl,
+)
+
+def _unix_make_variables_impl(ctx):
+    toolchain = ctx.toolchains[TOOLCHAIN_TYPE]
+    cmd_vars = {
+        "UNIX_%s" % cmd.upper(): cmd_path
+        for cmd in _commands
+        for cmd_path in [toolchain.commands[cmd]]
+        if cmd_path
+    }
+    return [platform_common.TemplateVariableInfo(cmd_vars)]
+
+unix_make_variables = rule(
+    doc = """
+Provides Unix toolchain commands as custom make variables.
+
+Make variables:
+  Provides a make variable of the form `UNIX_<COMMAND>` for each available
+  command, where `<COMMAND>` is the name of the command in upper case.
+
+Use `unix.MAKE_VARIABLES` instead of instantiating this rule yourself.
+
+Example:
+  >>> genrule(
+          name = "use-grep",
+          srcs = [":some-file"],
+          outs = ["grep-out"],
+          cmd = "$(UNIX_GREP) search $(execpath :some-file) > $(OUTS)",
+          toolchains = [unix.MAKE_VARIABLES],
+      )
+""",
+    implementation = _unix_make_variables_impl,
+    toolchains = [TOOLCHAIN_TYPE],
+)
+
+def _unix_config_impl(repository_ctx):
+    cpu = get_cpu_value(repository_ctx)
+    commands = {}
+    for cmd in _commands:
+        cmd_path = repository_ctx.which(cmd)
+        if cmd_path == None and cpu == "x64_windows":
+            cmd_path = repository_ctx.which(cmd + ".exe")
+        commands[cmd] = cmd_path
+    repository_ctx.file("BUILD.bazel", executable = False, content = """
+load("@bazel_skylib//lib:unix.bzl", "unix_toolchain")
+unix_toolchain(
+    name = "local_unix",
+    visibility = ["//visibility:public"],
+    {commands}
+)
+toolchain(
+    name = "local_unix_toolchain",
+    toolchain = ":local_unix",
+    toolchain_type = "{toolchain_type}",
+    exec_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:{os}",
+    ],
+    target_compatible_with = [
+        "@bazel_tools//platforms:x86_64",
+        "@bazel_tools//platforms:{os}",
+    ],
+)
+""".format(
+        commands = ",\n    ".join([
+            '{cmd} = "{path}"'.format(cmd = cmd, path = cmd_path)
+            for (cmd, cmd_path) in commands.items()
+            if cmd_path
+        ]),
+        os = {
+            "darwin": "osx",
+            "x64_windows": "windows",
+        }.get(cpu, "linux"),
+        toolchain_type = TOOLCHAIN_TYPE,
+    ))
+
+_unix_config = repository_rule(
+    environ = ["PATH"],
+    local = True,
+    implementation = _unix_config_impl,
+)
+
+def unix_configure(name = "local_unix_config"):
+    """Autodetect local Unix commands.
+
+    Scans the environment (`$PATH`) for standard shell commands, generates a
+    corresponding unix toolchain and registers the toolchain.
+    """
+    _unix_config(name = name)
+    native.register_toolchains("@{}//:local_unix_toolchain".format(name))
+
+unix = struct(
+    commands = _commands,
+    TOOLCHAIN_TYPE = TOOLCHAIN_TYPE,
+    MAKE_VARIABLES = MAKE_VARIABLES,
+)

--- a/lib/unix.bzl
+++ b/lib/unix.bzl
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/unix.bzl
+++ b/lib/unix.bzl
@@ -305,6 +305,7 @@ toolchain(
     ))
 
 _unix_config = repository_rule(
+    configure = True,
     environ = ["PATH"],
     local = True,
     implementation = _unix_config_impl,

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -11,6 +11,7 @@ load(":shell_tests.bzl", "shell_args_test_gen", "shell_test_suite")
 load(":structs_tests.bzl", "structs_test_suite")
 load(":types_tests.bzl", "types_test_suite")
 load(":unittest_tests.bzl", "unittest_passing_tests_suite")
+load(":unix_tests.bzl", "unix_test_suite")
 load(":versions_tests.bzl", "versions_test_suite")
 
 licenses(["notice"])
@@ -43,6 +44,8 @@ structs_test_suite()
 types_test_suite()
 
 unittest_passing_tests_suite()
+
+unix_test_suite()
 
 versions_test_suite()
 

--- a/tests/unix_tests.bzl
+++ b/tests/unix_tests.bzl
@@ -1,0 +1,108 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for unix.bzl."""
+
+load("//lib:new_sets.bzl", "sets")
+load("//lib:unittest.bzl", "analysistest", "asserts")
+load("//lib:unix.bzl", "unix")
+
+_UnixInfo = provider()
+
+def _get_unix_toolchain_impl(ctx):
+    return [_UnixInfo(
+        toolchain = ctx.toolchains[unix.TOOLCHAIN_TYPE],
+        variables = ctx.var,
+    )]
+
+get_unix_toolchain = rule(
+    implementation = _get_unix_toolchain_impl,
+    toolchains = [unix.TOOLCHAIN_TYPE],
+)
+
+def _command_items_test(ctx):
+    """The Unix toolchain should have an item for each command."""
+    env = analysistest.begin(ctx)
+    toolchain = analysistest.target_under_test(env)[_UnixInfo].toolchain
+
+    expected = sets.make(unix.commands)
+    actual = sets.make(toolchain.commands.keys())
+    msg = "Mismatch between Unix toolchain items and known commands"
+    asserts.new_set_equals(env, expected, actual, msg)
+
+    return analysistest.end(env)
+
+command_items_test = analysistest.make(_command_items_test)
+
+def _make_variables_test(ctx):
+    """The Unix toolchain should define a make variable for each found command."""
+    env = analysistest.begin(ctx)
+    toolchain = analysistest.target_under_test(env)[_UnixInfo].toolchain
+    variables = analysistest.target_under_test(env)[_UnixInfo].variables
+
+    for (cmd, cmd_path) in toolchain.commands.items():
+        varname = "UNIX_%s" % cmd.upper()
+        if cmd_path != None:
+            asserts.equals(env, cmd_path, variables[varname])
+        else:
+            asserts.false(env, varname in variables)
+
+    return analysistest.end(env)
+
+make_variables_test = analysistest.make(_make_variables_test)
+
+def _grep_genrule_test(ctx):
+    env = analysistest.begin(ctx)
+    actions = analysistest.target_actions(env)
+    toolchain = ctx.attr.unix_toolchain[_UnixInfo].toolchain
+
+    asserts.equals(env, 1, len(actions))
+    genrule_command = " ".join(actions[0].argv)
+    grep_path = toolchain.commands["grep"]
+    msg = "genrule command should contain path to grep"
+    asserts.true(env, genrule_command.find(grep_path) >= 0, msg)
+
+    return analysistest.end(env)
+
+grep_genrule_test = analysistest.make(
+    _grep_genrule_test,
+    attrs = {"unix_toolchain": attr.label()},
+)
+
+def unix_test_suite():
+    """Creates the test targets and test suite for unix.bzl tests."""
+    get_unix_toolchain(
+        name = "unix_toolchain",
+        toolchains = [unix.MAKE_VARIABLES],
+    )
+    command_items_test(
+        name = "command_items_test",
+        target_under_test = ":unix_toolchain",
+    )
+    make_variables_test(
+        name = "make_variables_test",
+        target_under_test = ":unix_toolchain",
+    )
+    native.genrule(
+        name = "unix_grep_genrule",
+        srcs = [":unix_tests.bzl"],
+        outs = ["unix_grep_genrule.txt"],
+        cmd = "$(UNIX_GREP) unix_grep_genrule $(execpath :unix_tests.bzl) > $(OUTS)",
+        toolchains = [unix.MAKE_VARIABLES],
+    )
+    grep_genrule_test(
+        name = "grep_genrule_test",
+        target_under_test = ":unix_grep_genrule",
+        unix_toolchain = ":unix_toolchain",
+    )

--- a/toolchains/unix/BUILD.bazel
+++ b/toolchains/unix/BUILD.bazel
@@ -1,0 +1,31 @@
+load("//lib:unix.bzl", "unix_make_variables")
+
+licenses(["notice"])
+
+toolchain_type(
+    name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+unix_make_variables(
+    name = "make_variables",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "test_deps",
+    testonly = True,
+    srcs = [
+        "BUILD.bazel",
+    ],
+    visibility = ["//:__subpackages__"],
+)
+
+# The files needed for distribution
+filegroup(
+    name = "distribution",
+    srcs = ["BUILD.bazel"],
+    visibility = [
+        "//:__pkg__",
+    ],
+)


### PR DESCRIPTION
As suggested by @laszlocsomor in https://github.com/tweag/rules_haskell/pull/1117#issuecomment-542082833 this moves the new Unix toolchain defined in [rules_haskell](https://github.com/tweag/rules_haskell/pull/1117) to Bazel skylib.

This PR addresses https://github.com/bazelbuild/bazel/issues/5265 and the related discussion in [bazel-dev](https://groups.google.com/d/msg/bazel-dev/Lo_DKft4Cpc/yiENPDUaAQAJ). It defines a toolchain for common Unix shell commands. The toolchain provides
* paths to commands in a dictionary.
    E.g. `unix_toolchain.commands["grep"] == "/usr/bin/grep"`
* a list of binpaths suitable for defining `$PATH`.
    E.g. `unix_toolchain.paths == ["/usr/bin"]`
* make variables for each available command.
    E.g. `$(UNIX_GREP)` as in
    ```
      genrule(
          name = "use-grep",
          srcs = [":some-file"],
          outs = [":grep-out"],
          cmd = "$(UNIX_GREP) search $(execpath :some-file) > $(OUTS)",
          toolchains = [unix.MAKE_VARIABLES],
      )
    ```

The toolchain can be instantiated using `unix_configure`, a repository rule that will search the local environment for the shell commands using `repository_ctx.which`. The implementation in rules_haskell offered another way to instantiate the toolchain using rules_nixpkgs, this can be moved into rules_nixpkgs to make it more broadly available once the Unix toolchain is in bazel_skylib.

I've added a test-suite in `unix_tests.bzl`. This requires the instantiation of a unix toolchain within bazel_skylib, so I've extended `external_setup.bzl` accordingly.