### PR TITLE
Remove links to maprules

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ s = shell.quote(p)
 
 * [analysis_test](docs/analysis_test_doc.md)
 * [build_test](docs/build_test_doc.md)
-* [`cmd_maprule` and `bash_maprule`](docs/maprule_doc.md)
 
 ## Writing a new module
 


### PR DESCRIPTION
This pair of rules was removed in 58068fe0cc28d8d5e0115bf0e7d80189628f35db, and the docs removed in 084758ff75463750f6c2476348ed9442e7860275 - the links were forgotten.