### PR TITLE
Remove --incompatible_remap_main_repo in build config

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,8 +6,6 @@ tasks:
     bazel: latest
     build_targets:
     - "//..."
-    build_flags:
-    - "--incompatible_remap_main_repo"
     test_targets:
     - "//..."
     test_flags:
@@ -19,8 +17,6 @@ tasks:
     bazel: latest
     build_targets:
     - "//..."
-    build_flags:
-    - "--incompatible_remap_main_repo"
     test_targets:
     - "//..."
     test_flags:
@@ -32,8 +28,6 @@ tasks:
     bazel: latest
     build_targets:
     - "//..."
-    build_flags:
-    - "--incompatible_remap_main_repo"
     test_targets:
     - "//..."
     test_flags:
@@ -45,8 +39,6 @@ tasks:
     bazel: latest
     build_targets:
     - "//..."
-    build_flags:
-    - "--incompatible_remap_main_repo"
     test_targets:
     - "--"
     - "//..."
@@ -61,8 +53,6 @@ tasks:
     bazel: last_green
     build_targets:
     - "//..."
-    build_flags:
-    - "--incompatible_remap_main_repo"
     test_targets:
     - "//..."
     test_flags:
@@ -74,8 +64,6 @@ tasks:
     bazel: last_green
     build_targets:
     - "//..."
-    build_flags:
-    - "--incompatible_remap_main_repo"
     test_targets:
     - "//..."
     test_flags:
@@ -87,8 +75,6 @@ tasks:
     bazel: last_green
     build_targets:
     - "//..."
-    build_flags:
-    - "--incompatible_remap_main_repo"
     test_targets:
     - "//..."
     test_flags:
@@ -100,8 +86,6 @@ tasks:
     bazel: last_green
     build_targets:
     - "//..."
-    build_flags:
-    - "--incompatible_remap_main_repo"
     test_targets:
     - "--"
     - "//..."


### PR DESCRIPTION
Due to https://github.com/bazelbuild/bazel/commit/8cb336ac3dc4d95005ab5b5243b51bf88cd6fdfe