### PR TITLE
More methods for modifying dicts

### DIFF
--- a/lib/dicts.bzl
+++ b/lib/dicts.bzl
@@ -18,7 +18,8 @@ def _add(*dictionaries, **kwargs):
     """Returns a new `dict` that has all the entries of the given dictionaries.
 
     If the same key is present in more than one of the input dictionaries, the
-    last of them in the argument list overrides any earlier ones.
+    last of them in the argument list overrides any earlier ones. If you want
+    to be alerted when there is an override see `dicts.unique_add`.
 
     This function is designed to take zero or one arguments as well as multiple
     dictionaries, so that it follows arithmetic identities and callers can avoid
@@ -37,7 +38,64 @@ def _add(*dictionaries, **kwargs):
         result.update(d)
     result.update(kwargs)
     return result
+    
+def _update_checking_uniqueness(result, d):
+    for k, v in d.items():
+        if k in result:
+            fail("Key '{}' is already in the dictionary".format(k))
+        result[k] = v
+    
+def _unique_add(*dictionaries, **kwargs):
+    """Like `dicts.add` but fails when there is a duplicate key.
+
+    Args:
+      *dictionaries: Zero or more dictionaries to be added.
+      **kwargs: Additional dictionary passed as keyword args.
+
+    Returns:
+      A new `dict` that has all the entries of the given dictionaries.
+    """
+    result = {}
+    for d in dictionaries:
+        _update_checking_uniqueness(result, d)
+    _update_checking_uniqueness(result, kwargs)
+    return result
+    
+def _without(dictionary, *keys):
+    """Returns a new `dict` that has all the keys except the ones you specified.
+    
+    Args:
+      dictionary: The dictionary to operate on.
+      *keys: The keys in the dictionary you want removed.
+
+    Returns:
+      A new `dict` that has all the keys except the ones you specified.
+    """
+    result = {}
+    for k, v in dictionary.items():
+        if k not in keys:
+            result[k] = v
+    return result
+
+def _only(dictionary, *keys):
+    """Returns a new `dict` that only has the keys you specified.
+      
+    Args:
+      dictionary: The dictionary to operate on.
+      *keys: The keys in the dictionary you want to keep.
+
+    Returns:
+      A new `dict` that only has the keys you specified.
+    """
+    result = {}
+    for k, v in dictionary.items():
+        if k in keys:
+            result[k] = v
+    return result
 
 dicts = struct(
     add = _add,
+    unique_add = _unique_add,
+    without = _without,
+    only = _only,
 )

--- a/tests/dicts_tests.bzl
+++ b/tests/dicts_tests.bzl
@@ -17,31 +17,48 @@
 load("//lib:dicts.bzl", "dicts")
 load("//lib:unittest.bzl", "asserts", "unittest")
 
-def _add_test(ctx):
-    """Unit tests for dicts.add."""
-    env = unittest.begin(ctx)
-
+def _shared_add_tests(env, method):
     # Test zero- and one-argument behavior.
-    asserts.equals(env, {}, dicts.add())
-    asserts.equals(env, {"a": 1}, dicts.add({"a": 1}))
-    asserts.equals(env, {"a": 1}, dicts.add(a = 1))
-    asserts.equals(env, {"a": 1, "b": 2}, dicts.add({"a": 1}, b = 2))
+    asserts.equals(env, {}, method())
+    asserts.equals(env, {"a": 1}, method({"a": 1}))
+    asserts.equals(env, {"a": 1}, method(a = 1))
+    asserts.equals(env, {"a": 1, "b": 2}, method({"a": 1}, b = 2))
 
     # Test simple two-argument behavior.
-    asserts.equals(env, {"a": 1, "b": 2}, dicts.add({"a": 1}, {"b": 2}))
-    asserts.equals(env, {"a": 1, "b": 2, "c": 3}, dicts.add({"a": 1}, {"b": 2}, c = 3))
+    asserts.equals(env, {"a": 1, "b": 2}, method({"a": 1}, {"b": 2}))
+    asserts.equals(env, {"a": 1, "b": 2, "c": 3}, method({"a": 1}, {"b": 2}, c = 3))
 
     # Test simple more-than-two-argument behavior.
     asserts.equals(
         env,
         {"a": 1, "b": 2, "c": 3, "d": 4},
-        dicts.add({"a": 1}, {"b": 2}, {"c": 3}, {"d": 4}),
+        method({"a": 1}, {"b": 2}, {"c": 3}, {"d": 4}),
     )
     asserts.equals(
         env,
         {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5},
-        dicts.add({"a": 1}, {"b": 2}, {"c": 3}, {"d": 4}, e = 5),
+        method({"a": 1}, {"b": 2}, {"c": 3}, {"d": 4}, e = 5),
     )
+
+    # Test some other boundary cases.
+    asserts.equals(env, {"a": 1}, method({"a": 1}, {}))
+
+    # Since dictionaries are passed around by reference, make sure that the
+    # result of method is always a *copy* by modifying it afterwards and
+    # ensuring that the original argument doesn't also reflect the change. We do
+    # this to protect against someone who might attempt to optimize the function
+    # by returning the argument itself in the one-argument case.
+    original = {"a": 1}
+    result = method(original)
+    result["a"] = 2
+    asserts.equals(env, 1, original["a"])
+
+
+def _add_test(ctx):
+    """Unit tests for dicts.add."""
+    env = unittest.begin(ctx)
+    
+    _shared_add_tests(env, dicts.add)
 
     # Test same-key overriding.
     asserts.equals(env, {"a": 100}, dicts.add({"a": 1}, {"a": 100}))
@@ -66,26 +83,54 @@ def _add_test(ctx):
         dicts.add({"a": 1}, a = 10, b = 5),
     )
 
-    # Test some other boundary cases.
-    asserts.equals(env, {"a": 1}, dicts.add({"a": 1}, {}))
+    return unittest.end(env)
+    
+add_test = unittest.make(_add_test)
+    
+def _unique_add_test(ctx):
+    """Unit tests for dicts.unique_add."""
+    env = unittest.begin(ctx)
 
-    # Since dictionaries are passed around by reference, make sure that the
-    # result of dicts.add is always a *copy* by modifying it afterwards and
-    # ensuring that the original argument doesn't also reflect the change. We do
-    # this to protect against someone who might attempt to optimize the function
-    # by returning the argument itself in the one-argument case.
-    original = {"a": 1}
-    result = dicts.add(original)
-    result["a"] = 2
-    asserts.equals(env, 1, original["a"])
+    _shared_add_tests(env, dicts.unique_add)
 
     return unittest.end(env)
 
-add_test = unittest.make(_add_test)
+unique_add_test = unittest.make(_unique_add_test)
+
+def _without_test(ctx):
+    """Unit tests for dicts.without."""
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, {"a": 100, "b": "c"}, dicts.without({"a": 100, "b": "c"}))
+    
+    asserts.equals(env, {"a": 100, "b": "c"}, dicts.without({"a": 100, "b": "c"}, "c"))
+    
+    asserts.equals(env, {"b": "c"}, dicts.without({"a": 100, "b": "c"}, "a"))
+
+    return unittest.end(env)
+    
+without_test = unittest.make(_without_test)
+
+def _only_test(ctx):
+    """Unit tests for dicts.only."""
+    env = unittest.begin(ctx)
+
+    asserts.equals(env, {}, dicts.only({"a": 100, "b": 100}))
+    
+    asserts.equals(env, {}, dicts.only({"a": 100, "b": 100}, "c"))
+    
+    asserts.equals(env, {"a": 100}, dicts.only({"a": 100, "b": "c"}, "a"))
+    
+    return unittest.end(env)
+    
+only_test = unittest.make(_only_test)
 
 def dicts_test_suite():
     """Creates the test targets and test suite for dicts.bzl tests."""
     unittest.suite(
         "dicts_tests",
         add_test,
+        unique_add_test,
+        without_test,
+        only_test,
     )


### PR DESCRIPTION
Just some more methods to help when working with dicts. I didn't add a test for the `unique_add` fail case because the tests in unittest_tests.bzl with `asserts.expect_failure` were marked as manual & I wanted to confirm how it should be added first.