### PR TITLE
Fix type parsing errors on "always true" conditions.

### DIFF
--- a/lib/selects.bzl
+++ b/lib/selects.bzl
@@ -234,11 +234,11 @@ def _config_setting_always_true(name, visibility):
     name_off = name + "_stamp_binary_off_check"
     native.config_setting(
         name = name_on,
-        values = {"stamp": True},
+        values = {"stamp": "1"},
     )
     native.config_setting(
         name = name_off,
-        values = {"stamp": False},
+        values = {"stamp": "0"},
     )
     return _config_setting_or_group(name, [":" + name_on, ":" + name_off], visibility)
 

--- a/tests/selects_tests.bzl
+++ b/tests/selects_tests.bzl
@@ -541,6 +541,54 @@ def _or_config_setting_group_single_setting_fails_test():
     )
 
 ###################################################
+# always_true_match_all_test
+###################################################
+always_true_match_all_test = analysistest.make(_expect_matches)
+
+def _always_true_match_all_test():
+    """Tests that "match_all=['//conditions:default']" always matches."""
+    selects.config_setting_group(
+        name = "all_always_match",
+        match_all = ["//conditions:default"],
+    )
+    boolean_attr_rule(
+        name = "match_always_true_rule",
+        myboolean = select(
+            {
+                ":all_always_match": True,
+            },
+        ),
+    )
+    always_true_match_all_test(
+        name = "always_true_match_all_test",
+        target_under_test = ":match_always_true_rule",
+    )
+
+###################################################
+# always_true_match_any_test
+###################################################
+always_true_match_any_test = analysistest.make(_expect_matches)
+
+def _always_true_match_any_test():
+    """Tests that "match_any=['//conditions:default']" always matches."""
+    selects.config_setting_group(
+        name = "any_always_match",
+        match_any = ["//conditions:default"],
+    )
+    boolean_attr_rule(
+        name = "match_any_always_true_rule",
+        myboolean = select(
+            {
+                ":any_always_match": True,
+            },
+        ),
+    )
+    always_true_match_any_test(
+        name = "always_true_match_any_test",
+        target_under_test = ":match_any_always_true_rule",
+    )
+
+###################################################
 # empty_config_setting_group_not_allowed_test
 ###################################################
 
@@ -586,6 +634,9 @@ def selects_test_suite():
     _or_config_setting_group_all_conds_match_test()
     _or_config_setting_group_single_setting_matches_test()
     _or_config_setting_group_single_setting_fails_test()
+
+    _always_true_match_all_test()
+    _always_true_match_any_test()
 
     # _empty_config_setting_group_not_allowed_test()
     # _and_and_or_not_allowed_together_test()


### PR DESCRIPTION
Specifically:

```
selects.config_setting_group(
    name = "always_true",
    match_any = ["//conditions:default"],
)
```

and

```
selects.config_setting_group(
    name = "always_true",
    match_all = ["//conditions:default"],
)
```

These should, as expected, always evaluate to True.
Their implementation had a bug that failed the build outright.