### PR TITLE
Stop given a depset as the first unnamed argument to the depset() constructor.

### DIFF
--- a/bzl_library.bzl
+++ b/bzl_library.bzl
@@ -24,8 +24,11 @@ StarlarkLibraryInfo = provider(
 )
 
 def _bzl_library_impl(ctx):
-    deps_files = [x.files for x in ctx.attr.deps]
-    all_files = depset(ctx.files.srcs, order = "postorder", transitive = deps_files)
+    all_files = depset(
+        ctx.files.srcs,
+        order = "postorder",
+        transitive = [x.files for x in ctx.attr.deps],
+    )
     return [
         # All dependent files should be listed in both `files` and in `runfiles`;
         # this ensures that a `bzl_library` can be referenced as `data` from


### PR DESCRIPTION
This is in preparation for flipping the Bazel flag --incompatible_disable_depset_items to true, making it an error to use the "items" parameter. See https://github.com/bazelbuild/bazel/issues/9017 for details.