### PR TITLE
Update visibility of files

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,10 +4,7 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files([
-    "LICENSE",
-    "lib.bzl",
-])
+exports_files(["LICENSE"])
 
 filegroup(
     name = "test_deps",

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -4,6 +4,12 @@ licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])
 
+# export bzl files for the documentation
+exports_files(
+    glob(["*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)
+
 bzl_library(
     name = "collections",
     srcs = ["collections.bzl"],

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -75,3 +75,9 @@ filegroup(
         "//:__pkg__",
     ],
 )
+
+# export bzl files for the documentation
+exports_files(
+    glob(["*.bzl"]),
+    visibility = ["//:__subpackages__"],
+)


### PR DESCRIPTION
Stardoc needs access to a file (with exports_files) in order to
generate its documentation.