### PR TITLE
Stop depending on rules_pkg through the federation.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,17 @@ workspace(name = "bazel_skylib")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
+http_archive(
+    name = "rules_pkg",
+    urls = [
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
+    ],
+    sha256 = "352c090cc3d3f9a6b4e676cf42a6047c16824959b438895a76c2989c6d7c246a",
+)
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+rules_pkg_dependencies()
+
 maybe(
     name = "bazel_federation",
     repo_rule = http_archive,


### PR DESCRIPTION
- while the federation code is in flux, this will mean less churn for skylib
- rules_pkg is only needed by developers for making a distribution, so this won't impact users.
- when we develop a new federation model, we can re-depend the right way.

fixes https://github.com/bazelbuild/bazel-federation/issues/117