### PR TITLE
Set config_settings in inspect_output_dirs_test to something not used…

### DIFF
--- a/tests/unittest_tests.bzl
+++ b/tests/unittest_tests.bzl
@@ -217,7 +217,7 @@ inspect_output_dirs_test = analysistest.make(
     # The output directories differ between the test and target under test when
     # the target under test is under a config transition.
     config_settings = {
-        "//command_line_option:compilation_mode": "fastbuild",
+        "//command_line_option:compilation_mode": "dbg",
     },
 )
 


### PR DESCRIPTION
… in the main build.

This resolves test failures, that were started by
https://github.com/bazelbuild/bazel/commit/a7a0d48fbeb059ee60e77580e5d05baeefdd5699