### PR TITLE
Update version stamp and CHANGELOG for 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+Release 1.0.3
+
+**Significant Changes**
+
+-   Move Gazelle extension to //gazelle/bzl and change package name
+-   Stop depending on rules_pkg through the federation. (#259)
+-   copy_file: Add parameter to allow symlinks (#252)
+-   Create Gazelle language for Starlark (#251)
+-   Create a helper rule (`select_file`) for selecting a file from outputs of another rule (#233)
+
+
+**Incompatible Changes**
+-   Remove links to maprules (#213)
+-   Remove old_sets.bzl (#231)
+    It has been deprecated for a while, the code is not really compatible with Bazel depset-related changes.
+
+**Contributors**
+Andrew Z Allen, Bocete, Bor Kae Hwang, irengrig, Jay Conrod, Jonathan B Coe, Marc Plano-Lesay, Robbert van Ginkel, Thomas Van Lenten, Yannic
+
+
 Release 1.0.0
 
 **Incompatible Changes**

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of bazel-skylib."""
 
-version = "1.0.1"
+version = "1.0.3"


### PR DESCRIPTION
This is a roll up of changes since 1.0.2.  In spite of a few being labeled incompatible, they are removal of deprecated features that should not break existing users.