### PR TITLE
Gazelle now handles imports from `@bazel_tools`

### DIFF
--- a/gazelle/bzl/testdata/bazel_tools/BUILD.in
+++ b/gazelle/bzl/testdata/bazel_tools/BUILD.in
@@ -1,0 +1,6 @@
+# Some comment to be preserved
+
+filegroup(
+    name = "allfiles",
+    srcs = glob(["**"]),
+)

--- a/gazelle/bzl/testdata/bazel_tools/BUILD.out
+++ b/gazelle/bzl/testdata/bazel_tools/BUILD.out
@@ -1,0 +1,15 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+# Some comment to be preserved
+
+filegroup(
+    name = "allfiles",
+    srcs = glob(["**"]),
+)
+
+bzl_library(
+    name = "foo",
+    srcs = ["foo.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["@bazel_tools//tools/build_defs/repo:http.bzl"],
+)

--- a/gazelle/bzl/testdata/bazel_tools/foo.bzl
+++ b/gazelle/bzl/testdata/bazel_tools/foo.bzl
@@ -1,0 +1,10 @@
+"""
+Doc string
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def wrapped_http_archive(**kwargs):
+    http_archive(
+        **kwargs
+    )


### PR DESCRIPTION
`@bazel_tools` is tricky since it is effectively a part of the standard
library that can not have a `bzl_library` attached to it. As a simple
fix for this, `bzl_library` can have a srcs dependency on it so that it
includes the transitive closure of all of its dependencies.

`@bazel_tools` imports are rewritten into the `srcs` attribute since
they are `exports_files`ed from the @bazel_tools.