### PR TITLE
Handle "internal" directory visibility

### DIFF
--- a/gazelle/bzl/testdata/private/nested/private/BUILD.out
+++ b/gazelle/bzl/testdata/private/nested/private/BUILD.out
@@ -3,5 +3,5 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "bar",
     srcs = ["bar.bzl"],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//nested:__subpackages__"],
 )

--- a/gazelle/bzl/testdata/private/nested/private/bar.bzl
+++ b/gazelle/bzl/testdata/private/nested/private/bar.bzl
@@ -1,0 +1,6 @@
+"""
+Test sample code.
+"""
+
+def func():
+    pass

--- a/gazelle/bzl/testdata/private/nested/private/inside/internal/BUILD.out
+++ b/gazelle/bzl/testdata/private/nested/private/inside/internal/BUILD.out
@@ -3,5 +3,5 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "bar",
     srcs = ["bar.bzl"],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//nested/private/inside:__subpackages__"],
 )

--- a/gazelle/bzl/testdata/private/nested/private/inside/internal/bar.bzl
+++ b/gazelle/bzl/testdata/private/nested/private/inside/internal/bar.bzl
@@ -1,0 +1,6 @@
+"""
+Test sample code.
+"""
+
+def func():
+    pass


### PR DESCRIPTION
Both "internal" and "private" directories should be treated the same way
and have visibility restrictions be placed upon them.