### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
+# More details on syntax here: https://help.github.com/articles/about-codeowners/
 * @c-parsons @laurentlb @jin @aiuto
-distribution/ @aiuto @fwe
-rules/ @juliexxia
-gazelle/ @achew22 @jayconrod
+/distribution/ @aiuto @fwe
+/rules/ @juliexxia
+/gazelle/ @achew22 @jayconrod


### PR DESCRIPTION
Previously permissions were granted to edit any file that existed in a directory
titled `gazelle`. Now grants have been given recursively.

Sorry for the inconsistency with Google3 `OWNERS` files.

@aiuto & @c-parsons . please review this very carefully since I have no prior 
experience with CODEOWNERS. I can say, however, that neither @jayconrod
nor I presently have the ability to submit code in the `/gazelle` dir, which is
why I'm messing with this.