### PR TITLE
Add paths.globmatch function

### DIFF
--- a/docs/paths_doc.md
+++ b/docs/paths_doc.md
@@ -67,6 +67,53 @@ included, unless omitting them would make the dirname empty.
 </table>
 
 
+## paths.globmatch
+
+<pre>
+paths.globmatch(<a href="#paths.globmatch-path">path</a>, <a href="#paths.globmatch-pattern">pattern</a>)
+</pre>
+
+Returns True if `path` matches `pattern`.
+
+The "*" wildcard in `pattern` matches zero or more characters.
+
+Examples:
+
+    globmatch("foo", "foo") == True
+    globmatch("foobar", "foo") == False
+    globmatch("foobar", "foo*") == True
+    globmatch("foobar", "f*b*") == True
+
+### Parameters
+
+<table class="params-table">
+  <colgroup>
+    <col class="col-param" />
+    <col class="col-description" />
+  </colgroup>
+  <tbody>
+    <tr id="paths.globmatch-path">
+      <td><code>path</code></td>
+      <td>
+        required.
+        <p>
+          Any string that should be matched against `pattern`
+        </p>
+      </td>
+    </tr>
+    <tr id="paths.dirname-pattern">
+      <td><code>pattern</code></td>
+      <td>
+        required.
+        <p>
+          String with optional '*' wildcards.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
 ## paths.is_absolute
 
 <pre>

--- a/lib/paths.bzl
+++ b/lib/paths.bzl
@@ -56,6 +56,43 @@ def _dirname(p):
         # os.path.dirname does.
         return prefix.rstrip("/")
 
+def _globmatch(path, pattern):
+    """Returns True if `path` matches `pattern`
+
+    The "*" wildcard in `pattern` matches zero or more characters.
+
+    Examples:
+      globmatch("foo", "foo") == True
+      globmatch("foobar", "foo") == False
+      globmatch("foobar", "foo*") == True
+      globmatch("foobar", "f*b*") == True
+
+    Args:
+      path: Any string that should be matched against `pattern`
+      pattern: string with optional "*" wildcards.
+
+    Returns:
+      True if `path` matches `pattern`
+    """
+    states = [(0,0)]
+
+    for state_idx in range(0, len(path)*len(pattern)+1):
+        if state_idx >= len(states):
+          break
+        i, j = states[state_idx]
+        for j in range(j, len(pattern)):
+            if pattern[j] == "*":
+                if i < len(path):
+                    states.append((i+1, j))
+            else:
+                if i >= len(path) or pattern[j] != path[i]:
+                    i = -1
+                    break
+                i += 1
+        if i == len(path):
+            return True
+    return False
+
 def _is_absolute(path):
     """Returns `True` if `path` is an absolute path.
 
@@ -233,6 +270,7 @@ def _split_extension(p):
 paths = struct(
     basename = _basename,
     dirname = _dirname,
+    globmatch = _globmatch,
     is_absolute = _is_absolute,
     join = _join,
     normalize = _normalize,

--- a/tests/paths_tests.bzl
+++ b/tests/paths_tests.bzl
@@ -66,6 +66,31 @@ def _dirname_test(ctx):
 
 dirname_test = unittest.make(_dirname_test)
 
+def _globmatch_test(ctx):
+    """Unit tests for paths.globmatch."""
+    env = unittest.begin(ctx)
+
+    asserts.true(env, paths.globmatch("", ""))
+    asserts.true(env, paths.globmatch("", "*"))
+    asserts.true(env, paths.globmatch("foobar", "f*o*bar"))
+    asserts.true(env, paths.globmatch("foo", "foo"))
+    asserts.true(env, paths.globmatch("foo", "foo*"))
+    asserts.true(env, paths.globmatch("foo", "foo****"))
+    asserts.true(env, paths.globmatch("foo", "f*o*"))
+    asserts.true(env, paths.globmatch("foobar", "f*o*bar"))
+    asserts.true(env, paths.globmatch("fofofofofofo", "f*f*f*f*f*fo"))
+    asserts.true(env, paths.globmatch("foooooooooooooooooof", "f*f"))
+
+    asserts.false(env, paths.globmatch("fofofofofofog", "f*f*f*f*f*f*f"))
+    asserts.false(env, paths.globmatch("foooooooooooooooooog", "f*f"))
+    asserts.false(env, paths.globmatch("foo", ""))
+    asserts.false(env, paths.globmatch("ba", "*b"))
+    asserts.false(env, paths.globmatch("foobar", "f*o*ba"))
+
+    return unittest.end(env)
+
+globmatch_test = unittest.make(_globmatch_test)
+
 def _is_absolute_test(ctx):
     """Unit tests for paths.is_absolute."""
     env = unittest.begin(ctx)
@@ -282,6 +307,7 @@ def paths_test_suite():
         "paths_tests",
         basename_test,
         dirname_test,
+        globmatch_test,
         is_absolute_test,
         join_test,
         normalize_test,


### PR DESCRIPTION
globmatch(path, pattern) returns True if `path` matches `pattern`.

The "*" wildcard in `pattern` matches zero or more characters.

Examples:

    globmatch("foo", "foo") == True
    globmatch("foobar", "foo") == False
    globmatch("foobar", "foo*") == True
    globmatch("foobar", "f*b*") == True

For performance, the following shortcuts can be added:

```
startcount = pattern.count("*")
if startcount == 0:
  return path == pattern
elif startcount == 1:
  start,_,end = pattern.partition("*")
  return path.startswith(start) and path.endswith(end)
```
