### PR TITLE
Add shebang lines to tests directory shell scripts

### DIFF
--- a/tests/copy_file/copy_file_tests.sh
+++ b/tests/copy_file/copy_file_tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/diff_test/diff_test_tests.sh
+++ b/tests/diff_test/diff_test_tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/write_file/write_file_tests.sh
+++ b/tests/write_file/write_file_tests.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Prevent Debian's lintian from complaining about scripts without shebangs. There does not seem to be a reason (that I can see) for the shebang being omitted. Since it is present in other shell scripts in the repository, I'm assuming that it's just an oversight that it's missing on these three files. 