### PR TITLE
Add write_file and copy_file docs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ s = shell.quote(p)
 
 * [analysis_test](docs/analysis_test_doc.md)
 * [build_test](docs/build_test_doc.md)
+* [write_file](docs/write_file_doc.md)
+* [copy_file](docs/copy_file_doc.md)
 
 ## Writing a new module
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ s = shell.quote(p)
 
 * [analysis_test](docs/analysis_test_doc.md)
 * [build_test](docs/build_test_doc.md)
-* [write_file](docs/write_file_doc.md)
 * [copy_file](docs/copy_file_doc.md)
+* [write_file](docs/write_file_doc.md)
 
 ## Writing a new module
 


### PR DESCRIPTION
I'd run across write_file from a Google search, and noticed, while using it, that its docs weren't in the README. 
So I figured I'd toss up a quick PR to add it and it's cousin, copy_file.
The README's list still isn't complete, but it's at least more complete.