### PR TITLE
to_json/to_proto methods on structs are deprecated and will be removed

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,13 +5,15 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 http_archive(
     name = "rules_pkg",
+    sha256 = "352c090cc3d3f9a6b4e676cf42a6047c16824959b438895a76c2989c6d7c246a",
     urls = [
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
     ],
-    sha256 = "352c090cc3d3f9a6b4e676cf42a6047c16824959b438895a76c2989c6d7c246a",
 )
+
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
 rules_pkg_dependencies()
 
 maybe(

--- a/lib/partial.bzl
+++ b/lib/partial.bzl
@@ -138,6 +138,7 @@ def _is_instance(v):
     Returns:
       True if v was created by `make`, False otherwise.
     """
+
     # Note that in bazel 3.7.0 and earlier, type(v.function) is the same
     # as the type of a function even if v.function is a rule. But we
     # cannot rely on this in later bazels due to breaking change
@@ -145,10 +146,10 @@ def _is_instance(v):
     #
     # Since this check is heuristic anyway, we simply check for the
     # presence of a "function" attribute without checking its type.
-    return type(v) == _a_struct_type \
-        and hasattr(v, "function") \
-        and hasattr(v, "args") and type(v.args) == _a_tuple_type \
-        and hasattr(v, "kwargs") and type(v.kwargs) == _a_dict_type
+    return type(v) == _a_struct_type and \
+           hasattr(v, "function") and \
+           hasattr(v, "args") and type(v.args) == _a_tuple_type and \
+           hasattr(v, "kwargs") and type(v.kwargs) == _a_dict_type
 
 partial = struct(
     make = _make,

--- a/lib/structs.bzl
+++ b/lib/structs.bzl
@@ -25,10 +25,11 @@ def _to_dict(s):
       transformation is only applied to the struct's fields and not to any
       nested values.
     """
-    attributes = dir(s)
-    attributes.remove("to_json")
-    attributes.remove("to_proto")
-    return {key: getattr(s, key) for key in attributes}
+    return {
+        key: getattr(s, key)
+        for key in dir(s)
+        if key != "to_json" and key != "to_proto"
+    }
 
 structs = struct(
     to_dict = _to_dict,

--- a/lib/structs.bzl
+++ b/lib/structs.bzl
@@ -25,6 +25,8 @@ def _to_dict(s):
       transformation is only applied to the struct's fields and not to any
       nested values.
     """
+    # to_json()/to_proto() are disabled by --incompatible_struct_has_no_methods
+    # and will be removed entirely in a future Bazel release.
     return {
         key: getattr(s, key)
         for key in dir(s)

--- a/lib/structs.bzl
+++ b/lib/structs.bzl
@@ -25,6 +25,7 @@ def _to_dict(s):
       transformation is only applied to the struct's fields and not to any
       nested values.
     """
+
     # to_json()/to_proto() are disabled by --incompatible_struct_has_no_methods
     # and will be removed entirely in a future Bazel release.
     return {

--- a/rules/private/copy_file_private.bzl
+++ b/rules/private/copy_file_private.bzl
@@ -65,11 +65,10 @@ def _copy_file_impl(ctx):
             target_file = ctx.file.src,
             is_executable = ctx.attr.is_executable,
         )
+    elif ctx.attr.is_windows:
+        copy_cmd(ctx, ctx.file.src, ctx.outputs.out)
     else:
-        if ctx.attr.is_windows:
-            copy_cmd(ctx, ctx.file.src, ctx.outputs.out)
-        else:
-            copy_bash(ctx, ctx.file.src, ctx.outputs.out)
+        copy_bash(ctx, ctx.file.src, ctx.outputs.out)
 
     files = depset(direct = [ctx.outputs.out])
     runfiles = ctx.runfiles(files = [ctx.outputs.out])

--- a/tests/copy_file/BUILD
+++ b/tests/copy_file/BUILD
@@ -80,8 +80,8 @@ genrule(
     output_to_bindir = 1,
     tools = [
         ":bin_gen",
-        ":bin_src",
         ":bin_gen_symlink",
+        ":bin_src",
         ":bin_src_symlink",
     ],
 )
@@ -147,8 +147,8 @@ copy_file(
     name = "copy_xsrc_symlink",
     src = "a_with_exec_bit.txt",
     out = "xout/a-out-symlink.sh",
-    is_executable = True,
     allow_symlink = True,
+    is_executable = True,
 )
 
 copy_file(
@@ -162,8 +162,8 @@ copy_file(
     name = "copy_xgen_symlink",
     src = ":gen",
     out = "xout/gen-out-symlink.sh",
-    is_executable = True,
     allow_symlink = True,
+    is_executable = True,
 )
 
 genrule(


### PR DESCRIPTION
We should not assume their existence.

Fixes https://github.com/bazelbuild/bazel-skylib/issues/294