### PR TITLE
Windows support for build_test

### DIFF
--- a/rules/BUILD
+++ b/rules/BUILD
@@ -49,16 +49,11 @@ bzl_library(
     srcs = ["common_settings.bzl"],
 )
 
-# Exported for build_test.bzl to make sure of, it is an implementation detail
-# of the rule and should not be directly used by anything else.
-exports_files(["empty_test.sh"])
-
 filegroup(
     name = "test_deps",
     testonly = True,
     srcs = [
         "BUILD",
-        "empty_test.sh",
     ] + glob(["*.bzl"]),
 )
 

--- a/rules/build_test.bzl
+++ b/rules/build_test.bzl
@@ -17,16 +17,13 @@
 load("//lib:new_sets.bzl", "sets")
 
 def _empty_test_impl(ctx):
-    is_windows = select({
-        "@bazel_tools//src/conditions:host_windows": True,
-        "//conditions:default": False,
-    })
-    extension = ".bat" if is_windows else ".sh"
+    extension = ".bat" if ctx.attr.is_windows else ".sh"
+    content = "exit 0" if ctx.attr.is_windows else "#!/bin/bash\nexit 0"
     executable = ctx.actions.declare_file(ctx.label.name + extension)
     ctx.actions.write(
         output = executable,
         is_executable = True,
-        content = "exit 0",
+        content = content,
     )
 
     return [DefaultInfo(
@@ -39,6 +36,7 @@ _empty_test = rule(
     implementation = _empty_test_impl,
     attrs = {
         "data": attr.label_list(allow_files = True),
+        "is_windows": attr.bool(mandatory = True),
     },
     test = True,
 )
@@ -108,5 +106,9 @@ def build_test(name, targets, **kwargs):
         name = name,
         data = test_data,
         size = kwargs.pop("size", "small"),  # Default to small for test size
+        is_windows = select({
+            "@bazel_tools//src/conditions:host_windows": True,
+            "//conditions:default": False,
+        }),
         **kwargs
     )

--- a/rules/build_test.bzl
+++ b/rules/build_test.bzl
@@ -16,15 +16,43 @@
 
 load("//lib:new_sets.bzl", "sets")
 
+def _empty_test_impl(ctx):
+    is_windows = select({
+        "@bazel_tools//src/conditions:host_windows": True,
+        "//conditions:default": False,
+    })
+    extension = ".bat" if is_windows else ".sh"
+    executable = ctx.actions.declare_file(ctx.label.name + extension)
+    ctx.actions.write(
+        output = executable,
+        is_executable = True,
+        content = "exit 0",
+    )
+
+    runfiles = []
+    for entry in ctx.attr.data:
+        runfiles += entry.files.to_list()
+
+    return [DefaultInfo(
+        files = depset([executable]),
+        executable = executable,
+        runfiles = ctx.runfiles(files = runfiles),
+    )]
+
+_empty_test = rule(
+    implementation = _empty_test_impl,
+    attrs = {
+        "data": attr.label_list(),
+    },
+    test = True,
+)
+
 def build_test(name, targets, **kwargs):
     """Test rule checking that other targets build.
 
     This works not by an instance of this test failing, but instead by
     the targets it depends on failing to build, and hence failing
     the attempt to run this test.
-
-    NOTE: At the moment, this won't work on Windows; but someone adding
-    support would be welcomed.
 
     Typical usage:
 
@@ -75,15 +103,13 @@ def build_test(name, targets, **kwargs):
             outs = [full_name + ".out"],
             testonly = 1,
             visibility = ["//visibility:private"],
-            # TODO: Does this need something else for Windows?
             cmd = "touch $@",
+            cmd_bat = "type nul > $@",
             **genrule_args
         )
 
-    native.sh_test(
+    _empty_test(
         name = name,
-        # TODO: Does this need something else for Windows?
-        srcs = ["@bazel_skylib//rules:empty_test.sh"],
         data = test_data,
         size = kwargs.pop("size", "small"),  # Default to small for test size
         **kwargs

--- a/rules/build_test.bzl
+++ b/rules/build_test.bzl
@@ -29,20 +29,16 @@ def _empty_test_impl(ctx):
         content = "exit 0",
     )
 
-    runfiles = []
-    for entry in ctx.attr.data:
-        runfiles += entry.files.to_list()
-
     return [DefaultInfo(
         files = depset([executable]),
         executable = executable,
-        runfiles = ctx.runfiles(files = runfiles),
+        runfiles = ctx.runfiles(files = ctx.files.data),
     )]
 
 _empty_test = rule(
     implementation = _empty_test_impl,
     attrs = {
-        "data": attr.label_list(),
+        "data": attr.label_list(allow_files = True),
     },
     test = True,
 )

--- a/rules/empty_test.sh
+++ b/rules/empty_test.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-# This is a support file for build_test.bzl, it shouldn't be used by anything else.
-exit 0


### PR DESCRIPTION
I have to point out that the approach used in this PR is a bit hacky as it marks `.bat` file as executable on Windows. AFAIK, in order to spawn processes on Windows, Bazel uses `CreateProcessW` function whose [docs](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw) says that caller should use `cmd.exe` as the application name and the batch file as one of `lpCommandLine` arguments. On the other hand, I don't know any Windows flavor that wouldn't run the batch file if it's passed as the application name to `CreateProcessW`