### PR TITLE
update links to bazel docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Release 0.9.0
     https://docs.google.com/document/d/1vc8v-kXjvgZOdQdnxPTaV0rrLxtP2XwnD2tAZlYJOqw/edit#bookmark=id.iiumwic0jphr
 -   selects.bzl: Add config_setting_group for config_setting AND/OR-chaining
     Implements
-    https://github.com/bazelbuild/proposals/blob/master/designs/2018-11-09-config-setting-chaining.md.
+    https://github.com/bazelbuild/proposals/blob/HEAD/designs/2018-11-09-config-setting-chaining.md.
 -   Make sets.bzl point to new_sets.bzl instead of old_sets.bzl. new_sets.bzl
     and old_sets.bzl should be removed in the following skylib release.
 

--- a/docs/build_test_doc.md
+++ b/docs/build_test_doc.md
@@ -57,7 +57,7 @@ Typical usage:
       <td>
         optional.
         <p>
-          The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
+          The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
         </p>
       </td>
     </tr>

--- a/docs/diff_test_doc.md
+++ b/docs/diff_test_doc.md
@@ -49,7 +49,7 @@ The test succeeds if the files' contents match.
       <td>
         optional.
         <p>
-          The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
+          The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
         </p>
       </td>
     </tr>

--- a/docs/native_binary_doc.md
+++ b/docs/native_binary_doc.md
@@ -55,7 +55,7 @@ You can "bazel run" this rule like any other binary rule, and use it as a tool i
       <td>
         optional.
         <p>
-          The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-binaries">common attributes for binaries</a>.
+          The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-binaries">common attributes for binaries</a>.
         </p>
       </td>
     </tr>
@@ -121,7 +121,7 @@ runfiles.
       <td>
         optional.
         <p>
-          The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
+          The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
         </p>
       </td>
     </tr>

--- a/docs/run_binary_doc.md
+++ b/docs/run_binary_doc.md
@@ -29,7 +29,7 @@ Runs a binary as a build action.<br/><br/>This rule does not require Bash (unlik
       <td>
         List of strings; optional
         <p>
-          Command line arguments of the binary.<br/><br/>Subject to<code><a href="https://docs.bazel.build/versions/master/be/make-variables.html#location">$(location)</a></code> expansion.
+          Command line arguments of the binary.<br/><br/>Subject to<code><a href="https://docs.bazel.build/versions/main/be/make-variables.html#location">$(location)</a></code> expansion.
         </p>
       </td>
     </tr>
@@ -38,7 +38,7 @@ Runs a binary as a build action.<br/><br/>This rule does not require Bash (unlik
       <td>
         <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a>; optional
         <p>
-          Environment variables of the action.<br/><br/>Subject to  <code><a href="https://docs.bazel.build/versions/master/be/make-variables.html#location">$(location)</a></code> expansion.
+          Environment variables of the action.<br/><br/>Subject to  <code><a href="https://docs.bazel.build/versions/main/be/make-variables.html#location">$(location)</a></code> expansion.
         </p>
       </td>
     </tr>

--- a/rules/build_test.bzl
+++ b/rules/build_test.bzl
@@ -41,7 +41,7 @@ def build_test(name, targets, **kwargs):
     Args:
       name: The name of the test rule.
       targets: A list of targets to ensure build.
-      **kwargs: The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
+      **kwargs: The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
     """
     if len(targets) == 0:
         fail("targets must be non-empty", "targets")

--- a/rules/common_settings.bzl
+++ b/rules/common_settings.bzl
@@ -18,7 +18,7 @@ These rules return a BuildSettingInfo with the value of the build setting.
 For label-typed settings, use the native label_flag and label_setting rules.
 
 More documentation on how to use build settings at
-https://docs.bazel.build/versions/master/skylark/config.html#user-defined-build-settings
+https://docs.bazel.build/versions/main/skylark/config.html#user-defined-build-settings
 """
 
 BuildSettingInfo = provider(

--- a/rules/diff_test.bzl
+++ b/rules/diff_test.bzl
@@ -135,7 +135,7 @@ def diff_test(name, file1, file2, **kwargs):
       name: The name of the test rule.
       file1: Label of the file to compare to <code>file2</code>.
       file2: Label of the file to compare to <code>file1</code>.
-      **kwargs: The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
+      **kwargs: The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
     """
     _diff_test(
         name = name,

--- a/rules/native_binary.bzl
+++ b/rules/native_binary.bzl
@@ -76,7 +76,7 @@ def native_binary(name, src, out, data = None, **kwargs):
       src: label; path of the pre-built executable
       out: output; an output name for the copy of the binary. (Bazel requires that this rule make a copy of 'src'.)
       data: list of labels; data dependencies
-      **kwargs: The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-binaries">common attributes for binaries</a>.
+      **kwargs: The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-binaries">common attributes for binaries</a>.
     """
     _native_binary(
         name = name,
@@ -101,7 +101,7 @@ def native_test(name, src, out, data = None, **kwargs):
       src: label; path of the pre-built executable
       out: output; an output name for the copy of the binary. (Bazel requires that this rule make a copy of 'src'.)
       data: list of labels; data dependencies
-      **kwargs: The <a href="https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
+      **kwargs: The <a href="https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests">common attributes for tests</a>.
     """
     _native_test(
         name = name,

--- a/rules/run_binary.bzl
+++ b/rules/run_binary.bzl
@@ -76,7 +76,7 @@ run_binary = rule(
         ),
         "env": attr.string_dict(
             doc = "Environment variables of the action.<br/><br/>Subject to " +
-                  " <code><a href=\"https://docs.bazel.build/versions/master/be/make-variables.html#location\">$(location)</a></code>" +
+                  " <code><a href=\"https://docs.bazel.build/versions/main/be/make-variables.html#location\">$(location)</a></code>" +
                   " expansion.",
         ),
         "srcs": attr.label_list(
@@ -91,7 +91,7 @@ run_binary = rule(
         ),
         "args": attr.string_list(
             doc = "Command line arguments of the binary.<br/><br/>Subject to" +
-                  "<code><a href=\"https://docs.bazel.build/versions/master/be/make-variables.html#location\">$(location)</a></code>" +
+                  "<code><a href=\"https://docs.bazel.build/versions/main/be/make-variables.html#location\">$(location)</a></code>" +
                   " expansion.",
         ),
     },


### PR DESCRIPTION
Docs are now served under  docs.bazel.build/versions/main