### PR TITLE
Remove `$` from grep regexes

### DIFF
--- a/tests/write_file/write_file_tests.sh
+++ b/tests/write_file/write_file_tests.sh
@@ -52,8 +52,8 @@ function test_write_empty_text() {
 
 function test_write_nonempty_text() {
   cat "$(rlocation bazel_skylib/tests/write_file/out/nonempty.txt)" >"$TEST_log"
-  expect_log '^aaa$'
-  expect_log '^bbb$'
+  expect_log '^aaa'
+  expect_log '^bbb'
 }
 
 function test_write_empty_bin() {
@@ -62,7 +62,7 @@ function test_write_empty_bin() {
 
 function test_write_nonempty_bin() {
   cat "$(rlocation bazel_skylib/tests/write_file/nonempty-bin-out.txt)" >"$TEST_log"
-  expect_log '^potato$'
+  expect_log '^potato'
 }
 
 run_suite "write_file_tests test suite"


### PR DESCRIPTION
Due to grep having dropped support for handling line-ending matches in a cross-platform way, grepping for `...$` will now fail on Windows, as it no longer ignores the CR part of the CRLF line endings on Windows.

This should turn this project green again on Bazel CI.