### PR TITLE
Remove unnecessary runfiles declaration of copy_file

### DIFF
--- a/rules/private/copy_file_private.bzl
+++ b/rules/private/copy_file_private.bzl
@@ -71,11 +71,10 @@ def _copy_file_impl(ctx):
         copy_bash(ctx, ctx.file.src, ctx.outputs.out)
 
     files = depset(direct = [ctx.outputs.out])
-    runfiles = ctx.runfiles(files = [ctx.outputs.out])
     if ctx.attr.is_executable:
-        return [DefaultInfo(files = files, runfiles = runfiles, executable = ctx.outputs.out)]
+        return [DefaultInfo(files = files, executable = ctx.outputs.out)]
     else:
-        return [DefaultInfo(files = files, runfiles = runfiles)]
+        return [DefaultInfo(files = files)]
 
 _ATTRS = {
     "src": attr.label(mandatory = True, allow_single_file = True),


### PR DESCRIPTION
`copy_file` unnecessarily declares the copied file as a `runfile` in its `DefaultInfo`, which "pollutes" the runfiles directory of all targets depending on the rule. For example, a `cc_library` with a `copy_file` target in its `hdrs` or `srcs` will also have the copied file as a runfile, which is not correct. Returning the copied file in `files` is sufficient for any depending rule to pick the file up as a runfile if necessary.