### PR TITLE
copy_file: Do not add non-executables to default_runfiles

### DIFF
--- a/rules/private/copy_file_private.bzl
+++ b/rules/private/copy_file_private.bzl
@@ -75,7 +75,10 @@ def _copy_file_impl(ctx):
     if ctx.attr.is_executable:
         return [DefaultInfo(files = files, runfiles = runfiles, executable = ctx.outputs.out)]
     else:
-        return [DefaultInfo(files = files, runfiles = runfiles)]
+        # Do not include the copied file into the default runfiles of the
+        # target, but ensure that it is picked up by native rule's data
+        # attribute despite https://github.com/bazelbuild/bazel/issues/15043.
+        return [DefaultInfo(files = files, data_runfiles = runfiles)]
 
 _ATTRS = {
     "src": attr.label(mandatory = True, allow_single_file = True),

--- a/rules/private/write_file_private.bzl
+++ b/rules/private/write_file_private.bzl
@@ -37,7 +37,10 @@ def _common_impl(ctx, is_windows, is_executable):
     if is_executable:
         return [DefaultInfo(files = files, runfiles = runfiles, executable = ctx.outputs.out)]
     else:
-        return [DefaultInfo(files = files, runfiles = runfiles)]
+        # Do not include the copied file into the default runfiles of the
+        # target, but ensure that it is picked up by native rule's data
+        # attribute despite https://github.com/bazelbuild/bazel/issues/15043.
+        return [DefaultInfo(files = files, data_runfiles = runfiles)]
 
 def _impl(ctx):
     return _common_impl(ctx, ctx.attr.is_windows, False)


### PR DESCRIPTION
copy_file currently includes the copied file in its runfiles even if it is not executable, which makes every rule depending on it have the file as a runfile (e.g. a `cc_library` depending on a copied header file via the hdrs attribute).

In an ideal world, according to https://docs.bazel.build/versions/main/skylark/rules.html#runfiles-features-to-avoid, `copy_file` would not need to specify any runfiles in the `DefaultInfo` it returns - specifying `files` should suffice. However, due to the existence of rules with legacy behavior, this would break compatibility (actually, already with `sh_test` in skylib's unit tests).

As a compromise that preserves compatibility with legacy rules but nevertheless cleans up the runfiles tree of depending rules, use the `data_runfiles` attribute of `DefaultInfo` if the copied file is not executable.

(Note: I noticed the problem with legacy rules only after submitting https://github.com/bazelbuild/bazel-skylib/pull/325, so please ignore that one).