### PR TITLE
Use more portable `#!/usr/bin/env bash` shebang instead of hardcoded /bin/bash.

### DIFF
--- a/docs/regenerate_docs.sh
+++ b/docs/regenerate_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/rules/build_test.bzl
+++ b/rules/build_test.bzl
@@ -18,7 +18,7 @@ load("//lib:new_sets.bzl", "sets")
 
 def _empty_test_impl(ctx):
     extension = ".bat" if ctx.attr.is_windows else ".sh"
-    content = "exit 0" if ctx.attr.is_windows else "#!/bin/bash\nexit 0"
+    content = "exit 0" if ctx.attr.is_windows else "#!/usr/bin/env bash\nexit 0"
     executable = ctx.actions.declare_file(ctx.label.name + extension)
     ctx.actions.write(
         output = executable,

--- a/rules/diff_test.bzl
+++ b/rules/diff_test.bzl
@@ -86,7 +86,7 @@ if %ERRORLEVEL% neq 0 (
         test_bin = ctx.actions.declare_file(ctx.label.name + "-test.sh")
         ctx.actions.write(
             output = test_bin,
-            content = r"""#!/bin/bash
+            content = r"""#!/usr/bin/env bash
 set -euo pipefail
 F1="{file1}"
 F2="{file2}"

--- a/tests/analysis_test_test.sh
+++ b/tests/analysis_test_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/tests/common_settings_test.sh
+++ b/tests/common_settings_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/tests/copy_file/BUILD
+++ b/tests/copy_file/BUILD
@@ -169,5 +169,5 @@ copy_file(
 genrule(
     name = "gen",
     outs = ["b.txt"],
-    cmd = "echo -e '#!/bin/bash\necho potato' > $@",
+    cmd = "echo -e '#!/usr/bin/env bash\necho potato' > $@",
 )

--- a/tests/copy_file/a.txt
+++ b/tests/copy_file/a.txt
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo aaa

--- a/tests/copy_file/a_with_exec_bit.txt
+++ b/tests/copy_file/a_with_exec_bit.txt
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo aaa

--- a/tests/copy_file/copy_file_tests.sh
+++ b/tests/copy_file/copy_file_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #
@@ -42,25 +42,25 @@ source "$(rlocation bazel_skylib/tests/unittest.bash)" \
 
 function test_copy_src() {
   cat "$(rlocation bazel_skylib/tests/copy_file/out/a-out.txt)" >"$TEST_log"
-  expect_log '^#!/bin/bash$'
+  expect_log '^#!/usr/bin/env bash$'
   expect_log '^echo aaa$'
 }
 
 function test_copy_src_symlink() {
   cat "$(rlocation bazel_skylib/tests/copy_file/out/a-out-symlink.txt)" >"$TEST_log"
-  expect_log '^#!/bin/bash$'
+  expect_log '^#!/usr/bin/env bash$'
   expect_log '^echo aaa$'
 }
 
 function test_copy_gen() {
   cat "$(rlocation bazel_skylib/tests/copy_file/out/gen-out.txt)" >"$TEST_log"
-  expect_log '^#!/bin/bash$'
+  expect_log '^#!/usr/bin/env bash$'
   expect_log '^echo potato$'
 }
 
 function test_copy_gen_symlink() {
   cat "$(rlocation bazel_skylib/tests/copy_file/out/gen-out-symlink.txt)" >"$TEST_log"
-  expect_log '^#!/bin/bash$'
+  expect_log '^#!/usr/bin/env bash$'
   expect_log '^echo potato$'
 }
 

--- a/tests/diff_test/diff_test_tests.sh
+++ b/tests/diff_test/diff_test_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/tests/run_binary/BUILD
+++ b/tests/run_binary/BUILD
@@ -82,7 +82,7 @@ write_file(
             "@echo>>%OUT% ENV_PATH_CMD=(%ENV_PATH_CMD%)",
         ],
         "//conditions:default": [
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "echo > \"$OUT\" \"arg1=($1)\"",
             "echo >> \"$OUT\" \"arg2=($2)\"",
             "echo >> \"$OUT\" \"ENV_LOCATION=($ENV_LOCATION)\"",

--- a/tests/shell_tests.bzl
+++ b/tests/shell_tests.bzl
@@ -69,7 +69,7 @@ def _shell_args_test_gen_impl(ctx):
         "back`echo q`uote",
     ]
     script_content = "\n".join([
-        "#!/bin/bash",
+        "#!/usr/bin/env bash",
         "myarray=" + shell.array_literal(args),
         'output=$(echo "${myarray[@]}")',
         # For logging:

--- a/tests/unittest.bash
+++ b/tests/unittest.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2015 The Bazel Authors. All rights reserved.
 #
@@ -21,7 +21,7 @@
 # A typical test suite looks like so:
 #
 #   ------------------------------------------------------------------------
-#   #!/bin/bash
+#   #!/usr/bin/env bash
 #
 #   source path/to/unittest.bash || exit 1
 #

--- a/tests/unittest_test.sh
+++ b/tests/unittest_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #

--- a/tests/write_file/BUILD
+++ b/tests/write_file/BUILD
@@ -113,7 +113,7 @@ write_file(
     name = "write_nonempty_bin",
     out = "out/nonempty.sh",
     content = [
-        "#!/bin/bash",
+        "#!/usr/bin/env bash",
         "echo potato",
     ],
     is_executable = True,

--- a/tests/write_file/write_file_tests.sh
+++ b/tests/write_file/write_file_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Bazel Authors. All rights reserved.
 #


### PR DESCRIPTION
Address https://github.com/bazelbuild/bazel-skylib/issues/328 
Should also help add a toolchain in `rules_foreign_cc` for FreeBSD: https://github.com/bazelbuild/rules_foreign_cc/pull/794