### PR TITLE
Add support for 'loading' unit tests, which evaluate a LOADING phase.

### DIFF
--- a/docs/unittest_doc.md
+++ b/docs/unittest_doc.md
@@ -374,12 +374,12 @@ Creates a loading phase test environment and test_suite.
 loading phase environment passed to other loadingtest functions
 
 
-<a id="#loadingtest.asserts"></a>
+<a id="#loadingtest.equals"></a>
 
-## loadingtest.asserts
+## loadingtest.equals
 
 <pre>
-loadingtest.asserts(<a href="#loadingtest.asserts-env">env</a>, <a href="#loadingtest.asserts-test_case">test_case</a>, <a href="#loadingtest.asserts-expected">expected</a>, <a href="#loadingtest.asserts-actual">actual</a>)
+loadingtest.equals(<a href="#loadingtest.equals-env">env</a>, <a href="#loadingtest.equals-test_case">test_case</a>, <a href="#loadingtest.equals-expected">expected</a>, <a href="#loadingtest.equals-actual">actual</a>)
 </pre>
 
 Creates a test case for asserting state at LOADING phase.
@@ -389,36 +389,14 @@ Creates a test case for asserting state at LOADING phase.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="loadingtest.asserts-env"></a>env |  Loading test env created from loadingtest.make   |  none |
-| <a id="loadingtest.asserts-test_case"></a>test_case |  Name of the test case   |  none |
-| <a id="loadingtest.asserts-expected"></a>expected |  Expected value to test   |  none |
-| <a id="loadingtest.asserts-actual"></a>actual |  Actual value received.   |  none |
+| <a id="loadingtest.equals-env"></a>env |  Loading test env created from loadingtest.make   |  none |
+| <a id="loadingtest.equals-test_case"></a>test_case |  Name of the test case   |  none |
+| <a id="loadingtest.equals-expected"></a>expected |  Expected value to test   |  none |
+| <a id="loadingtest.equals-actual"></a>actual |  Actual value received.   |  none |
 
 **RETURNS**
 
 None, creates test case
-
-
-<a id="#loadingtest.suite"></a>
-
-## loadingtest.suite
-
-<pre>
-loadingtest.suite(<a href="#loadingtest.suite-env">env</a>)
-</pre>
-
-Creates a test suite for loading phase tests.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="loadingtest.suite-env"></a>env |  env created with loadingtest.make   |  none |
-
-**RETURNS**
-
-None, creates test_suite
 
 
 <a id="#register_unittest_toolchains"></a>

--- a/docs/unittest_doc.md
+++ b/docs/unittest_doc.md
@@ -352,6 +352,75 @@ Asserts that the given `condition` is true.
 | <a id="asserts.true-msg"></a>msg |  An optional message that will be printed that describes the failure. If omitted, a default will be used.   |  <code>"Expected condition to be true, but was false."</code> |
 
 
+<a id="#loadingtest.make"></a>
+
+## loadingtest.make
+
+<pre>
+loadingtest.make(<a href="#loadingtest.make-name">name</a>)
+</pre>
+
+Creates a loading phase test environment and test_suite.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="loadingtest.make-name"></a>name |  name of the suite of tests to create   |  none |
+
+**RETURNS**
+
+loading phase environment passed to other loadingtest functions
+
+
+<a id="#loadingtest.asserts"></a>
+
+## loadingtest.asserts
+
+<pre>
+loadingtest.asserts(<a href="#loadingtest.asserts-env">env</a>, <a href="#loadingtest.asserts-test_case">test_case</a>, <a href="#loadingtest.asserts-expected">expected</a>, <a href="#loadingtest.asserts-actual">actual</a>)
+</pre>
+
+Creates a test case for asserting state at LOADING phase.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="loadingtest.asserts-env"></a>env |  Loading test env created from loadingtest.make   |  none |
+| <a id="loadingtest.asserts-test_case"></a>test_case |  Name of the test case   |  none |
+| <a id="loadingtest.asserts-expected"></a>expected |  Expected value to test   |  none |
+| <a id="loadingtest.asserts-actual"></a>actual |  Actual value received.   |  none |
+
+**RETURNS**
+
+None, creates test case
+
+
+<a id="#loadingtest.suite"></a>
+
+## loadingtest.suite
+
+<pre>
+loadingtest.suite(<a href="#loadingtest.suite-env">env</a>)
+</pre>
+
+Creates a test suite for loading phase tests.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="loadingtest.suite-env"></a>env |  env created with loadingtest.make   |  none |
+
+**RETURNS**
+
+None, creates test_suite
+
+
 <a id="#register_unittest_toolchains"></a>
 
 ## register_unittest_toolchains

--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -602,18 +602,7 @@ def _loading_make(name):
     )
     return struct(name = name)
 
-def _loading_suite(env):
-    """Creates a test suite for loading phase tests.
-
-    Args:
-       env: env created with loadingtest.make
-
-    Returns:
-       None, creates test_suite
-    """
-    pass
-
-def _loading_asserts(env, test_case, expected, actual):
+def _loading_assert_equals(env, test_case, expected, actual):
     """Creates a test case for asserting state at LOADING phase.
 
     Args:
@@ -665,6 +654,5 @@ analysistest = struct(
 
 loadingtest = struct(
     make = _loading_make,
-    asserts = _loading_asserts,
-    suite = _loading_suite,
+    equals = _loading_assert_equals,
 )

--- a/tests/unittest_tests.bzl
+++ b/tests/unittest_tests.bzl
@@ -15,7 +15,7 @@
 """Unit tests for unittest.bzl."""
 
 load("//lib:partial.bzl", "partial")
-load("//lib:unittest.bzl", "analysistest", "asserts", "unittest")
+load("//lib:unittest.bzl", "analysistest", "asserts", "loadingtest", "unittest")
 
 ###################################
 ####### basic_failing_test ########
@@ -307,6 +307,13 @@ inspect_output_dirs_test = analysistest.make(
     },
 )
 
+def _loading_phase_test(env):
+    loadingtest.asserts(env, "self_glob", ["unittest_tests.bzl"], native.glob(["unittest_tests.bzl"]))
+
+    # now use our own calls to assert we created a test case rule and test_suite for it.
+    loadingtest.asserts(env, "test_exists", True, native.existing_rule(env.name + "_self_glob") != None)
+    loadingtest.asserts(env, "suite_exists", True, native.existing_rule(env.name + "_tests") != None)
+
 #########################################
 
 # buildifier: disable=unnamed-macro
@@ -376,3 +383,6 @@ def unittest_passing_tests_suite():
         name = "inspect_output_dirs_fake_target",
         tags = ["manual"],
     )
+
+    loading_env = loadingtest.make("selftest")
+    _loading_phase_test(loading_env)

--- a/tests/unittest_tests.bzl
+++ b/tests/unittest_tests.bzl
@@ -308,11 +308,11 @@ inspect_output_dirs_test = analysistest.make(
 )
 
 def _loading_phase_test(env):
-    loadingtest.asserts(env, "self_glob", ["unittest_tests.bzl"], native.glob(["unittest_tests.bzl"]))
+    loadingtest.equals(env, "self_glob", ["unittest_tests.bzl"], native.glob(["unittest_tests.bzl"]))
 
     # now use our own calls to assert we created a test case rule and test_suite for it.
-    loadingtest.asserts(env, "test_exists", True, native.existing_rule(env.name + "_self_glob") != None)
-    loadingtest.asserts(env, "suite_exists", True, native.existing_rule(env.name + "_tests") != None)
+    loadingtest.equals(env, "test_exists", True, native.existing_rule(env.name + "_self_glob") != None)
+    loadingtest.equals(env, "suite_exists", True, native.existing_rule(env.name + "_tests") != None)
 
 #########################################
 


### PR DESCRIPTION
This is a relatively simple addition to unittest that statically creates
rules that either explicitly fail or not depending on if the test case is valid during LOADING phase of bazel.  The test conditions are evaluated entirely in loading phase, but if we want an actual test to fail rather than just `fail()` killing the build, we can use this to assert state and report test failures.