### PR TITLE
Unbreak backwards compatibility of analysistest.make

### DIFF
--- a/docs/unittest_doc.md
+++ b/docs/unittest_doc.md
@@ -37,8 +37,8 @@ unittest_toolchain(<a href="#unittest_toolchain-name">name</a>, <a href="#unitte
 ## analysistest.make
 
 <pre>
-analysistest.make(<a href="#analysistest.make-impl">impl</a>, <a href="#analysistest.make-doc">doc</a>, <a href="#analysistest.make-expect_failure">expect_failure</a>, <a href="#analysistest.make-attrs">attrs</a>, <a href="#analysistest.make-fragments">fragments</a>, <a href="#analysistest.make-config_settings">config_settings</a>,
-                  <a href="#analysistest.make-extra_target_under_test_aspects">extra_target_under_test_aspects</a>)
+analysistest.make(<a href="#analysistest.make-impl">impl</a>, <a href="#analysistest.make-expect_failure">expect_failure</a>, <a href="#analysistest.make-attrs">attrs</a>, <a href="#analysistest.make-fragments">fragments</a>, <a href="#analysistest.make-config_settings">config_settings</a>,
+                  <a href="#analysistest.make-extra_target_under_test_aspects">extra_target_under_test_aspects</a>, <a href="#analysistest.make-doc">doc</a>)
 </pre>
 
 Creates an analysis test rule from its implementation function.
@@ -73,12 +73,12 @@ Recall that names of test rules must end in `_test`.
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="analysistest.make-impl"></a>impl |  The implementation function of the unit test.   |  none |
-| <a id="analysistest.make-doc"></a>doc |  A description of the rule that can be extracted by documentation generating tools.   |  <code>""</code> |
 | <a id="analysistest.make-expect_failure"></a>expect_failure |  If true, the analysis test will expect the target_under_test to fail. Assertions can be made on the underlying failure using asserts.expect_failure   |  <code>False</code> |
 | <a id="analysistest.make-attrs"></a>attrs |  An optional dictionary to supplement the attrs passed to the unit test's <code>rule()</code> constructor.   |  <code>{}</code> |
 | <a id="analysistest.make-fragments"></a>fragments |  An optional list of fragment names that can be used to give rules access to language-specific parts of configuration.   |  <code>[]</code> |
 | <a id="analysistest.make-config_settings"></a>config_settings |  A dictionary of configuration settings to change for the target under test and its dependencies. This may be used to essentially change 'build flags' for the target under test, and may thus be utilized to test multiple targets with different flags in a single build   |  <code>{}</code> |
 | <a id="analysistest.make-extra_target_under_test_aspects"></a>extra_target_under_test_aspects |  An optional list of aspects to apply to the target_under_test in addition to those set up by default for the test harness itself.   |  <code>[]</code> |
+| <a id="analysistest.make-doc"></a>doc |  A description of the rule that can be extracted by documentation generating tools.   |  <code>""</code> |
 
 **RETURNS**
 

--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -206,12 +206,12 @@ _action_retrieving_aspect = aspect(
 # TODO(cparsons): Provide more full documentation on analysis testing in README.
 def _make_analysis_test(
         impl,
-        doc = "",
         expect_failure = False,
         attrs = {},
         fragments = [],
         config_settings = {},
-        extra_target_under_test_aspects = []):
+        extra_target_under_test_aspects = [],
+        doc = ""):
     """Creates an analysis test rule from its implementation function.
 
     An analysis test verifies the behavior of a "real" rule target by examining
@@ -252,6 +252,7 @@ def _make_analysis_test(
           flags in a single build
       extra_target_under_test_aspects: An optional list of aspects to apply to the target_under_test
           in addition to those set up by default for the test harness itself.
+      doc: A description of the rule that can be extracted by documentation generating tools.
 
     Returns:
       A rule definition that should be stored in a global whose name ends in


### PR DESCRIPTION
Parameter 2 should be `expect_failure`. Let's not break users of positional parameters
unnecessarily.

Followup to https://github.com/bazelbuild/bazel-skylib/pull/343