### PR TITLE
Remove unused, empty //rules:bins filegroup, allowing us to simplify distribution/BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -75,10 +75,3 @@ filegroup(
         "//toolchains/unittest:distribution",
     ] + glob(["*.bzl"]),
 )
-
-filegroup(
-    name = "bins",
-    srcs = [
-        "//rules:bins",
-    ],
-)

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -10,8 +10,8 @@ package(
 pkg_tar(
     name = "bazel-skylib-%s" % version,
     srcs = ["//:distribution"],
-    mode = "0644",
     extension = "tar.gz",
+    mode = "0644",
     # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",
     strip_prefix = ".",

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -6,37 +6,15 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
-pkg_tar(
-    name = "srcs",
-    srcs = ["//:distribution"],
-    mode = "0444",
-    # Make it owned by root so it does not have the uid of the CI robot.
-    owner = "0.0",
-    package_dir = "",
-    strip_prefix = ".",
-)
-
-pkg_tar(
-    name = "bins",
-    srcs = ["//:bins"],
-    mode = "0555",
-    # Make it owned by root so it does not have the uid of the CI robot.
-    owner = "0.0",
-    package_dir = "",
-    strip_prefix = ".",
-)
-
 # Build the artifact to put on the github release page.
 pkg_tar(
     name = "bazel-skylib-%s" % version,
+    srcs = ["//:distribution"],
+    mode = "0644",
     extension = "tar.gz",
     # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",
     strip_prefix = ".",
-    deps = [
-        ":bins.tar",
-        ":srcs.tar",
-    ],
 )
 
 print_rel_notes(

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -68,14 +68,6 @@ filegroup(
     ],
 )
 
-filegroup(
-    name = "bins",
-    srcs = glob(["*.sh"]),
-    visibility = [
-        "//:__pkg__",
-    ],
-)
-
 # export bzl files for the documentation
 exports_files(
     glob(["*.bzl"]),


### PR DESCRIPTION
//rules:bins has not been used since 14f17ae7f71f347b5e720fca55e33df40bc4e5d5

Alternative to https://github.com/bazelbuild/bazel-skylib/pull/358