### PR TITLE
Update changelog and version for release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Release 1.2.1
+
+Bugfix release: fixes build failure with --incompatible_disallow_empty_glob
+(#359)
+
+**Contributors**
+
+Alexandre Rostovtsev, Ivo List
+
+
 Release 1.2.0
 
 **New Features**

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,4 @@
 # limitations under the License.
 """The version of bazel-skylib."""
 
-version = "1.2.0"
+version = "1.2.1"


### PR DESCRIPTION
Make a point release to unbreak users who set `--incompatible_disallow_empty_glob`. See discussion in https://github.com/bazelbuild/bazel-skylib/pull/359