### PR TITLE
Allow using python3 for timestamps on macOS and BSD

### DIFF
--- a/tests/unittest.bash
+++ b/tests/unittest.bash
@@ -674,10 +674,12 @@ if [ "$UNAME" = "linux" ] || [[ "$UNAME" =~ msys_nt* ]]; then
     }
 else
     function timestamp() {
-      # OS X and FreeBSD do not have %N so python is the best we can do
+      # macOS and BSDs do not have %N, so Python is the best we can do.
+      # LC_ALL=C works around python 3.8 and 3.9 crash on macOS when the
+      # filesystem encoding is unspecified (e.g. when LANG=en_US).
       local PYTHON=python
       command -v python3 &> /dev/null && PYTHON=python3
-      "${PYTHON}" -c 'import time; print(int(round(time.time() * 1000)))'
+      LC_ALL=C "${PYTHON}" -c 'import time; print(int(round(time.time() * 1000)))'
     }
 fi
 

--- a/tests/unittest.bash
+++ b/tests/unittest.bash
@@ -675,7 +675,9 @@ if [ "$UNAME" = "linux" ] || [[ "$UNAME" =~ msys_nt* ]]; then
 else
     function timestamp() {
       # OS X and FreeBSD do not have %N so python is the best we can do
-      python -c 'import time; print int(round(time.time() * 1000))'
+      local PYTHON=python
+      command -v python3 &> /dev/null && PYTHON=python3
+      "${PYTHON}" -c 'import time; print(int(round(time.time() * 1000)))'
     }
 fi
 


### PR DESCRIPTION
Note that macOS 12.3 removed python2.