### PR TITLE
Add shell. escape_for_bat for escaping strings in Windows .bat scripts

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -10,6 +10,7 @@ tasks:
     - "//..."
     test_flags:
     - "--test_env=PATH"
+    - "--test_tag_filters=-windows"
 
   ubuntu1604_latest:
     name: "Latest Bazel"
@@ -21,6 +22,7 @@ tasks:
     - "//..."
     test_flags:
     - "--test_env=PATH"
+    - "--test_tag_filters=-windows"
 
   macos_latest:
     name: "Latest Bazel"
@@ -32,6 +34,7 @@ tasks:
     - "//..."
     test_flags:
     - "--test_env=PATH"
+    - "--test_tag_filters=-windows"
 
   windows_latest:
     name: "Latest Bazel"
@@ -58,6 +61,7 @@ tasks:
     - "//..."
     test_flags:
     - "--test_env=PATH"
+    - "--test_tag_filters=-windows"
 
   ubuntu1604_last_green:
     name: "Last Green Bazel"
@@ -69,6 +73,7 @@ tasks:
     - "//..."
     test_flags:
     - "--test_env=PATH"
+    - "--test_tag_filters=-windows"
 
   macos_last_green:
     name: "Last Green Bazel"
@@ -80,6 +85,7 @@ tasks:
     - "//..."
     test_flags:
     - "--test_env=PATH"
+    - "--test_tag_filters=-windows"
 
   windows_last_green:
     name: "Last Green Bazel"

--- a/docs/shell_doc.md
+++ b/docs/shell_doc.md
@@ -59,18 +59,24 @@ shell metacharacters.)
 A quoted version of the string that can be passed to a shell command.
 
 
-<a id="#shell.escape_cmd"></a>
+<a id="#shell.escape_for_bat"></a>
 
-## shell.escape_cmd
+## shell.escape_for_bat
 
 <pre>
-shell.escape_cmd(<a href="#shell.escape_cmd-s">s</a>, <a href="#shell.escape_cmd-delayedexpansion">delayedexpansion</a>)
+shell.escape_for_bat(<a href="#shell.escape_for_bat-s">s</a>, <a href="#shell.escape_for_bat-delayed_expansion">delayed_expansion</a>, <a href="#shell.escape_for_bat-escape_quotes">escape_quotes</a>)
 </pre>
 
-Escapes any Windows metacharacters in the string for use in a cmd.exe command.
+Escapes Windows metacharacters in a string for use in a .bat script.
 
 This function makes no attempt to quote the string due to context-sensitive
-and unintuitive treatment of `"` in Windows command parsing.
+and unintuitive treatment of `"` in Windows command parsing (e.g. `echo`
+echoes `"` characters).
+
+This function assumes that the string will not be embedded within a larger
+quoted string.
+
+See https://stackoverflow.com/questions/4094699 for gory details.
 
 
 **PARAMETERS**
@@ -78,8 +84,9 @@ and unintuitive treatment of `"` in Windows command parsing.
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="shell.escape_cmd-s"></a>s |  The string to escape.   |  none |
-| <a id="shell.escape_cmd-delayedexpansion"></a>delayedexpansion |  Escape <code>!</code> for shells in ENABLEDELAYEDEXPANSION mode.   |  <code>False</code> |
+| <a id="shell.escape_for_bat-s"></a>s |  The string to escape.   |  none |
+| <a id="shell.escape_for_bat-delayed_expansion"></a>delayed_expansion |  Escape <code>!</code> for <code>setlocal ENABLEDELAYEDEXPANSION</code> mode.   |  <code>False</code> |
+| <a id="shell.escape_for_bat-escape_quotes"></a>escape_quotes |  Escape <code>"</code> using <code>/</code>; respected by executables which use the MSVCRT command line parser, but not by older commands like <code>echo</code>.   |  <code>False</code> |
 
 **RETURNS**
 

--- a/docs/shell_doc.md
+++ b/docs/shell_doc.md
@@ -59,3 +59,30 @@ shell metacharacters.)
 A quoted version of the string that can be passed to a shell command.
 
 
+<a id="#shell.escape_cmd"></a>
+
+## shell.escape_cmd
+
+<pre>
+shell.escape_cmd(<a href="#shell.escape_cmd-s">s</a>, <a href="#shell.escape_cmd-delayedexpansion">delayedexpansion</a>)
+</pre>
+
+Escapes any Windows metacharacters in the string for use in a cmd.exe command.
+
+This function makes no attempt to quote the string due to context-sensitive
+and unintuitive treatment of `"` in Windows command parsing.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="shell.escape_cmd-s"></a>s |  The string to escape.   |  none |
+| <a id="shell.escape_cmd-delayedexpansion"></a>delayedexpansion |  Escape <code>!</code> for shells in ENABLEDELAYEDEXPANSION mode.   |  <code>False</code> |
+
+**RETURNS**
+
+An escaped version of the string that can be passed to a command in cmd.exe.
+
+

--- a/docs/shell_doc.md
+++ b/docs/shell_doc.md
@@ -90,6 +90,7 @@ See https://stackoverflow.com/questions/4094699 for gory details.
 
 **RETURNS**
 
-An escaped version of the string that can be passed to a command in cmd.exe.
+An escaped version of the string that can be used as part of a command
+line in a Windows batch file.
 
 

--- a/lib/shell.bzl
+++ b/lib/shell.bzl
@@ -67,7 +67,8 @@ def _escape_for_bat(s, delayed_expansion = False, escape_quotes = False):
         the MSVCRT command line parser, but not by older commands like `echo`.
 
     Returns:
-      An escaped version of the string that can be passed to a command in cmd.exe.
+      An escaped version of the string that can be used as part of a command
+      line in a Windows batch file.
     """
     escaped = ""
     in_quote = False

--- a/lib/shell.bzl
+++ b/lib/shell.bzl
@@ -48,7 +48,32 @@ def _quote(s):
     """
     return "'" + s.replace("'", "'\\''") + "'"
 
+def _escape_cmd(s, delayedexpansion = False):
+    """Escapes any Windows metacharacters in the string for use in a cmd.exe command.
+
+    This function makes no attempt to quote the string due to context-sensitive
+    and unintuitive treatment of `"` in Windows command parsing.
+
+    Args:
+      s: The string to escape.
+      delayedexpansion: Escape `!` for shells in ENABLEDELAYEDEXPANSION mode.
+
+    Returns:
+      An escaped version of the string that can be passed to a command in cmd.exe.
+    """
+    s = s.replace("^", "^^") \
+        .replace("%", "%%") \
+        .replace("&", "^&") \
+        .replace("\\", "^\\") \
+        .replace("<", "^<") \
+        .replace(">", "^>") \
+        .replace("|", "^|")
+    if delayedexpansion:
+        s = s.replace("!", "^^!")  # must be escaped twice for two expansions
+    return s
+
 shell = struct(
     array_literal = _array_literal,
     quote = _quote,
+    escape_cmd = _escape_cmd,
 )

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -6,7 +6,7 @@ load(":new_sets_tests.bzl", "new_sets_test_suite")
 load(":partial_tests.bzl", "partial_test_suite")
 load(":paths_tests.bzl", "paths_test_suite")
 load(":selects_tests.bzl", "selects_test_suite")
-load(":shell_tests.bzl", "shell_args_test_gen", "shell_test_suite", "shell_windows_cmd_spawn_e2e_test")
+load(":shell_tests.bzl", "shell_args_test_gen", "shell_test_suite", "shell_windows_bat_e2e_test")
 load(":structs_tests.bzl", "structs_test_suite")
 load(":types_tests.bzl", "types_test_suite")
 load(":unittest_tests.bzl", "unittest_passing_tests_suite")
@@ -98,8 +98,8 @@ sh_test(
     srcs = [":shell_spawn_e2e_test_src"],
 )
 
-shell_windows_cmd_spawn_e2e_test(
-    name = "shell_windows_cmd_spawn_e2e_test",
+shell_windows_bat_e2e_test(
+    name = "shell_windows_bat_e2e_test",
     tags = [
         "manual",
         "windows",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -6,7 +6,7 @@ load(":new_sets_tests.bzl", "new_sets_test_suite")
 load(":partial_tests.bzl", "partial_test_suite")
 load(":paths_tests.bzl", "paths_test_suite")
 load(":selects_tests.bzl", "selects_test_suite")
-load(":shell_tests.bzl", "shell_args_test_gen", "shell_test_suite")
+load(":shell_tests.bzl", "shell_args_test_gen", "shell_test_suite", "shell_windows_cmd_spawn_e2e_test")
 load(":structs_tests.bzl", "structs_test_suite")
 load(":types_tests.bzl", "types_test_suite")
 load(":unittest_tests.bzl", "unittest_passing_tests_suite")
@@ -96,4 +96,12 @@ shell_args_test_gen(
 sh_test(
     name = "shell_spawn_e2e_test",
     srcs = [":shell_spawn_e2e_test_src"],
+)
+
+shell_windows_cmd_spawn_e2e_test(
+    name = "shell_windows_cmd_spawn_e2e_test",
+    tags = [
+        "manual",
+        "windows",
+    ],
 )

--- a/tests/shell_tests.bzl
+++ b/tests/shell_tests.bzl
@@ -166,7 +166,7 @@ def shell_windows_bat_e2e_test(name, **kwargs):
     This macro writes and executes a .bat file which echoes an escaped string, and
     verifies that the output is identical to the original string.
     """
-    evil_string = '>out.txt <in.txt %path%, !path! "^xyz^" & echo foo | echo \\"bar\\"'
+    evil_string = '>out.txt <in.txt %path%, !path! "(x,y,z)" & echo foo | echo \\"bar\\"'
     write_file(
         name = "_%s_original" % name,
         content = [evil_string + "\r\n"],


### PR DESCRIPTION
In particular, we want this to be able to fix https://github.com/bazelbuild/bazel-skylib/issues/344 for both Unix and Windows.