### PR TITLE
Remove unnecessary wrapper macro for expand_template rule

### DIFF
--- a/docs/expand_template_doc.md
+++ b/docs/expand_template_doc.md
@@ -8,26 +8,25 @@ A rule that performes template expansion.
 ## expand_template
 
 <pre>
-expand_template(<a href="#expand_template-name">name</a>, <a href="#expand_template-template">template</a>, <a href="#expand_template-substitutions">substitutions</a>, <a href="#expand_template-out">out</a>)
+expand_template(<a href="#expand_template-name">name</a>, <a href="#expand_template-out">out</a>, <a href="#expand_template-substitutions">substitutions</a>, <a href="#expand_template-template">template</a>)
 </pre>
 
 Template expansion
 
-This performs a simple search over the template file for the keys in substitutions,
-and replaces them with the corresponding values.
+This performs a simple search over the template file for the keys in
+substitutions, and replaces them with the corresponding values.
 
-There is no special syntax for the keys.
-To avoid conflicts, you would need to explicitly add delimiters to the key strings, for example "{KEY}" or "@KEY@".
+There is no special syntax for the keys. To avoid conflicts, you would need to
+explicitly add delimiters to the key strings, for example "{KEY}" or "@KEY@".
+
+**ATTRIBUTES**
 
 
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="expand_template-name"></a>name |  The name of the rule.   |  none |
-| <a id="expand_template-template"></a>template |  The template file to expand   |  none |
-| <a id="expand_template-substitutions"></a>substitutions |  A dictionary mapping strings to their substitutions   |  none |
-| <a id="expand_template-out"></a>out |  The destination of the expanded file   |  none |
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="expand_template-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="expand_template-out"></a>out |  The destination of the expanded file.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="expand_template-substitutions"></a>substitutions |  A dictionary mapping strings to their substitutions.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | required |  |
+| <a id="expand_template-template"></a>template |  The template file to expand.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 

--- a/rules/expand_template.bzl
+++ b/rules/expand_template.bzl
@@ -22,34 +22,29 @@ def _expand_template_impl(ctx):
         substitutions = ctx.attr.substitutions,
     )
 
-_expand_template = rule(
+expand_template = rule(
     implementation = _expand_template_impl,
+    doc = """Template expansion
+
+This performs a simple search over the template file for the keys in
+substitutions, and replaces them with the corresponding values.
+
+There is no special syntax for the keys. To avoid conflicts, you would need to
+explicitly add delimiters to the key strings, for example "{KEY}" or "@KEY@".""",
     attrs = {
-        "template": attr.label(mandatory = True, allow_single_file = True),
-        "substitutions": attr.string_dict(mandatory = True),
-        "out": attr.output(mandatory = True),
+        "template": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "The template file to expand.",
+        ),
+        "substitutions": attr.string_dict(
+            mandatory = True,
+            doc = "A dictionary mapping strings to their substitutions.",
+        ),
+        "out": attr.output(
+            mandatory = True,
+            doc = "The destination of the expanded file.",
+        ),
     },
     output_to_genfiles = True,
 )
-
-def expand_template(name, template, substitutions, out):
-    """Template expansion
-
-    This performs a simple search over the template file for the keys in substitutions,
-    and replaces them with the corresponding values.
-
-    There is no special syntax for the keys.
-    To avoid conflicts, you would need to explicitly add delimiters to the key strings, for example "{KEY}" or "@KEY@".
-
-    Args:
-      name: The name of the rule.
-      template: The template file to expand
-      out: The destination of the expanded file
-      substitutions: A dictionary mapping strings to their substitutions
-    """
-    _expand_template(
-        name = name,
-        template = template,
-        substitutions = substitutions,
-        out = out,
-    )


### PR DESCRIPTION
Followup to #330: remove the wrapper macro and export the rule directly; the macro
does not serve any useful function. As a side effect, this fixes the inability to
set tags etc., since the macro did not support **kwargs.