### PR TITLE
Fix diff_test on Windows with --enable_runfiles --nolegacy_external_runfiles

### DIFF
--- a/rules/diff_test.bzl
+++ b/rules/diff_test.bzl
@@ -46,8 +46,14 @@ for /F "tokens=2* usebackq" %%i in (`findstr.exe /l /c:"!F1! " "%MF%"`) do (
   set RF1=!RF1:/=\\!
 )
 if "!RF1!" equ "" (
-  if exist "{file1}" (
-    set RF1="{file1}"
+  if "%RUNFILES_MANIFEST_ONLY%" neq "1" if exist "%RUNFILES_DIR%\\%F1%" (
+    set RF1="%RUNFILES_DIR%\\%F1%"
+  ) else (
+    if exist "{file1}" (
+      set RF1="{file1}"
+    )
+  )
+  if "!RF1!" neq "" (
     set RF1=!RF1:/=\\!
   ) else (
     echo>&2 ERROR: !F1! not found
@@ -59,8 +65,14 @@ for /F "tokens=2* usebackq" %%i in (`findstr.exe /l /c:"!F2! " "%MF%"`) do (
   set RF2=!RF2:/=\\!
 )
 if "!RF2!" equ "" (
-  if exist "{file2}" (
-    set RF2="{file2}"
+  if "%RUNFILES_MANIFEST_ONLY%" neq "1" if exist "%RUNFILES_DIR%\\%F2%" (
+    set RF2="%RUNFILES_DIR%\\%F2%"
+  ) else (
+    if exist "{file2}" (
+      set RF2="{file2}"
+    )
+  )
+  if "!RF2!" neq "" (
     set RF2=!RF2:/=\\!
   ) else (
     echo>&2 ERROR: !F2! not found

--- a/tests/diff_test/diff_test_tests.sh
+++ b/tests/diff_test/diff_test_tests.sh
@@ -54,7 +54,7 @@ function import_diff_test() {
 }
 
 function assert_simple_diff_test() {
-  local -r flag="$1"
+  local -r flags="$1"
   local -r ws="${TEST_TMPDIR}/$2"
   local -r subdir="$3"
 
@@ -80,17 +80,17 @@ eof
   echo bar > "$ws/$subdir/b.txt"
 
   (cd "$ws" && \
-   bazel test "$flag" "//${subdir%/}:same" --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} "//${subdir%/}:same" --test_output=errors 1>"$TEST_log" 2>&1 \
      || fail "expected success")
 
   (cd "$ws" && \
-   bazel test "$flag" "//${subdir%/}:different" --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} "//${subdir%/}:different" --test_output=errors 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
   expect_log "FAIL: files \"${subdir}a.txt\" and \"${subdir}b.txt\" differ"
 }
 
 function assert_from_ext_repo() {
-  local -r flag="$1"
+  local -r flags="$1"
   local -r ws="${TEST_TMPDIR}/$2"
 
   # Import the rule to an external repository.
@@ -175,47 +175,59 @@ diff_test(
 eof
 
   (cd "$ws/main" && \
-   bazel test "$flag" //:same --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} //:same --test_output=errors 1>"$TEST_log" 2>&1 \
      || fail "expected success")
 
   (cd "$ws/main" && \
-   bazel test "$flag" //:different1 --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} //:different1 --test_output=errors 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
   expect_log 'FAIL: files "external/ext1/foo/foo.txt" and "external/ext2/foo/bar.txt" differ'
 
   (cd "$ws/main" && \
-   bazel test "$flag" //:different2 --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} //:different2 --test_output=errors 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
   expect_log 'FAIL: files "external/ext1/foo/foo.txt" and "ext1/foo/foo.txt" differ'
 
   (cd "$ws/main" && \
-   bazel test "$flag" //:different3 --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} //:different3 --test_output=errors 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
   expect_log 'FAIL: files "ext2/foo/foo.txt" and "external/ext2/foo/foo.txt" differ'
 }
 
 function test_simple_diff_test_with_legacy_external_runfiles() {
-  assert_simple_diff_test "--legacy_external_runfiles" "${FUNCNAME[0]}" ""
+  assert_simple_diff_test "--enable_runfiles --legacy_external_runfiles" "${FUNCNAME[0]}" ""
 }
 
 function test_simple_diff_test_without_legacy_external_runfiles() {
-  assert_simple_diff_test "--nolegacy_external_runfiles" "${FUNCNAME[0]}" ""
+  assert_simple_diff_test "--enable_runfiles --nolegacy_external_runfiles" "${FUNCNAME[0]}" ""
+}
+
+function test_simple_diff_test_with_manifest() {
+  assert_simple_diff_test "--noenable_runfiles" "${FUNCNAME[0]}" ""
 }
 
 function test_directory_named_external_with_legacy_external_runfiles() {
-  assert_simple_diff_test "--legacy_external_runfiles" "${FUNCNAME[0]}" "path/to/direcotry/external/in/name/"
+  assert_simple_diff_test "--enable_runfiles --legacy_external_runfiles" "${FUNCNAME[0]}" "path/to/direcotry/external/in/name/"
 }
 
 function test_directory_named_external_without_legacy_external_runfiles() {
-  assert_simple_diff_test "--nolegacy_external_runfiles" "${FUNCNAME[0]}" "path/to/direcotry/external/in/name/"
+  assert_simple_diff_test "--enable_runfiles --nolegacy_external_runfiles" "${FUNCNAME[0]}" "path/to/direcotry/external/in/name/"
+}
+
+function test_directory_named_external_with_manifest() {
+  assert_simple_diff_test "--noenable_runfiles" "${FUNCNAME[0]}" "path/to/direcotry/external/in/name/"
 }
 
 function test_from_ext_repo_with_legacy_external_runfiles() {
-  assert_from_ext_repo "--legacy_external_runfiles" "${FUNCNAME[0]}"
+  assert_from_ext_repo "--enable_runfiles --legacy_external_runfiles" "${FUNCNAME[0]}"
 }
 
 function test_from_ext_repo_without_legacy_external_runfiles() {
-  assert_from_ext_repo "--nolegacy_external_runfiles" "${FUNCNAME[0]}"
+  assert_from_ext_repo "--enable_runfiles --nolegacy_external_runfiles" "${FUNCNAME[0]}"
+}
+
+function test_from_ext_repo_with_manifest() {
+  assert_from_ext_repo "--noenable_runfiles" "${FUNCNAME[0]}"
 }
 
 function test_failure_message() {


### PR DESCRIPTION
And make sure our test suite exercises both manifest-based and runfiles-based
code paths for diff_test.

Fixes #376.