### PR TITLE
feat: bzlmod setup

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -96,4 +96,18 @@ tasks:
     - "--test_env=LOCALAPPDATA"
     - "--test_tag_filters=-no_windows"
 
+  ubuntu1804_last_green_bzlmod:
+    name: "Last Green Bazel (with bzlmod)"
+    platform: ubuntu1804
+    bazel: last_green
+    build_targets:
+    - "//..."
+    test_targets:
+    - "//..."
+    build_flags:
+      - "--experimental_enable_bzlmod"
+    test_flags:
+      - "--experimental_enable_bzlmod"
+      - "--test_env=PATH"
+
 buildifier: latest

--- a/BUILD
+++ b/BUILD
@@ -7,7 +7,10 @@ package(default_visibility = ["//visibility:public"])
 # buildifier: disable=skylark-comment
 # gazelle:exclude skylark_library.bzl
 
-exports_files(["LICENSE"])
+exports_files([
+    "LICENSE",
+    "MODULE.bazel",
+])
 
 filegroup(
     name = "test_deps",
@@ -69,6 +72,7 @@ filegroup(
         "BUILD",
         "CODEOWNERS",
         "CONTRIBUTORS",
+        "WORKSPACE.bzlmod",
         "//lib:distribution",
         "//rules:distribution",
         "//rules/private:distribution",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,10 @@ register_toolchains(
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
+
+### INTERNAL ONLY - lines after this are not included in the release packaging.
+
+# Gazelle extension is experimental
 bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.33.0")
 bazel_dep(name = "gazelle", repo_name = "bazel_gazelle", version = "0.26.0")
 
@@ -23,6 +27,7 @@ go_deps.module(
 
 use_repo(go_deps, "com_github_bazelbuild_buildtools")
 
+# Build-only / test-only dependencies
 bazel_dep(name = "stardoc", dev_dependency = True, repo_name = "io_bazel_stardoc", version = "0.5.1")
 bazel_dep(name = "rules_pkg", dev_dependency = True, version = "0.5.1")
 bazel_dep(name = "rules_cc", dev_dependency = True, version = "0.0.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,17 +10,19 @@ register_toolchains(
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_go", version = "0.33.0", repo_name = "io_bazel_rules_go")
-bazel_dep(name = "gazelle", version = "0.26.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.33.0")
+bazel_dep(name = "gazelle", repo_name = "bazel_gazelle", version = "0.26.0")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+
 go_deps.module(
     path = "github.com/bazelbuild/buildtools",
-    version = "v0.0.0-20220531122519-a43aed7014c8",
     sum = "h1:fmdo+fvvWlhldUcqkhAMpKndSxMN3vH5l7yow5cEaiQ=",
+    version = "v0.0.0-20220531122519-a43aed7014c8",
 )
+
 use_repo(go_deps, "com_github_bazelbuild_buildtools")
 
-bazel_dep(name = "stardoc", version = "0.5.1", repo_name = "io_bazel_stardoc", dev_dependency = True)
-bazel_dep(name = "rules_pkg", version = "0.5.1", dev_dependency = True)
-bazel_dep(name = "rules_cc", version = "0.0.1", dev_dependency = True)
+bazel_dep(name = "stardoc", dev_dependency = True, repo_name = "io_bazel_stardoc", version = "0.5.1")
+bazel_dep(name = "rules_pkg", dev_dependency = True, version = "0.5.1")
+bazel_dep(name = "rules_cc", dev_dependency = True, version = "0.0.1")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,26 @@
+module(
+    name = "bazel_skylib",
+    compatibility_level = 1,
+    version = "1.2.1",
+)
+
+register_toolchains(
+    "//toolchains/unittest:cmd_toolchain",
+    "//toolchains/unittest:bash_toolchain",
+)
+
+bazel_dep(name = "platforms", version = "0.0.4")
+bazel_dep(name = "rules_go", version = "0.33.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.26.0", repo_name = "bazel_gazelle")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.module(
+    path = "github.com/bazelbuild/buildtools",
+    version = "v0.0.0-20220531122519-a43aed7014c8",
+    sum = "h1:fmdo+fvvWlhldUcqkhAMpKndSxMN3vH5l7yow5cEaiQ=",
+)
+use_repo(go_deps, "com_github_bazelbuild_buildtools")
+
+bazel_dep(name = "stardoc", version = "0.5.1", repo_name = "io_bazel_stardoc", dev_dependency = True)
+bazel_dep(name = "rules_pkg", version = "0.5.1", dev_dependency = True)
+bazel_dep(name = "rules_cc", version = "0.0.1", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,10 +6,10 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 maybe(
     name = "io_bazel_rules_go",
     repo_rule = http_archive,
-    sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
+    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
     ],
 )
 
@@ -26,10 +26,10 @@ go_register_toolchains(version = "1.17.1")
 maybe(
     http_archive,
     name = "io_bazel_stardoc",
-    sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
+    sha256 = "aa814dae0ac400bbab2e8881f9915c6f47c49664bf087c409a15f90438d2c23e",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
-        "https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.1/stardoc-0.5.1.tar.gz",
     ],
 )
 

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -1,0 +1,2 @@
+# Workaround so that targets prefixed with @bazel_skylib still work
+workspace(name = "bazel_skylib")

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -6,10 +6,20 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
+genrule(
+    name = "distro_module_bazel",
+    srcs = ["//:MODULE.bazel"],
+    outs = ["MODULE.bazel"],
+    cmd = "sed -e '/### INTERNAL ONLY/,$$d' $(location //:MODULE.bazel) >$@",
+)
+
 # Build the artifact to put on the github release page.
 pkg_tar(
     name = "bazel-skylib-%s" % version,
-    srcs = ["//:distribution"],
+    srcs = [
+        "distro_module_bazel",
+        "//:distribution",
+    ],
     extension = "tar.gz",
     mode = "0644",
     # Make it owned by root so it does not have the uid of the CI robot.

--- a/docs/analysis_test_doc.md
+++ b/docs/analysis_test_doc.md
@@ -2,7 +2,7 @@
 
 A test verifying other targets can be successfully analyzed as part of a `bazel test`
 
-<a id="#analysis_test"></a>
+<a id="analysis_test"></a>
 
 ## analysis_test
 

--- a/docs/build_test_doc.md
+++ b/docs/build_test_doc.md
@@ -2,7 +2,7 @@
 
 A test verifying other targets build as part of a `bazel test`
 
-<a id="#build_test"></a>
+<a id="build_test"></a>
 
 ## build_test
 

--- a/docs/collections_doc.md
+++ b/docs/collections_doc.md
@@ -2,7 +2,7 @@
 
 Skylib module containing functions that operate on collections.
 
-<a id="#collections.after_each"></a>
+<a id="collections.after_each"></a>
 
 ## collections.after_each
 
@@ -25,7 +25,7 @@ Inserts `separator` after each item in `iterable`.
 A new list with `separator` after each item in `iterable`.
 
 
-<a id="#collections.before_each"></a>
+<a id="collections.before_each"></a>
 
 ## collections.before_each
 
@@ -48,7 +48,7 @@ Inserts `separator` before each item in `iterable`.
 A new list with `separator` before each item in `iterable`.
 
 
-<a id="#collections.uniq"></a>
+<a id="collections.uniq"></a>
 
 ## collections.uniq
 

--- a/docs/common_settings_doc.md
+++ b/docs/common_settings_doc.md
@@ -9,7 +9,7 @@ More documentation on how to use build settings at
 https://docs.bazel.build/versions/main/skylark/config.html#user-defined-build-settings
 
 
-<a id="#bool_flag"></a>
+<a id="bool_flag"></a>
 
 ## bool_flag
 
@@ -27,7 +27,7 @@ A bool-typed build setting that can be set on the command line
 | <a id="bool_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#bool_setting"></a>
+<a id="bool_setting"></a>
 
 ## bool_setting
 
@@ -45,7 +45,7 @@ A bool-typed build setting that cannot be set on the command line
 | <a id="bool_setting-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#int_flag"></a>
+<a id="int_flag"></a>
 
 ## int_flag
 
@@ -63,7 +63,7 @@ An int-typed build setting that can be set on the command line
 | <a id="int_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#int_setting"></a>
+<a id="int_setting"></a>
 
 ## int_setting
 
@@ -81,7 +81,7 @@ An int-typed build setting that cannot be set on the command line
 | <a id="int_setting-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#string_flag"></a>
+<a id="string_flag"></a>
 
 ## string_flag
 
@@ -100,7 +100,7 @@ A string-typed build setting that can be set on the command line
 | <a id="string_flag-values"></a>values |  The list of allowed values for this setting. An error is raised if any other value is given.   | List of strings | optional | [] |
 
 
-<a id="#string_list_flag"></a>
+<a id="string_list_flag"></a>
 
 ## string_list_flag
 
@@ -118,7 +118,7 @@ A string list-typed build setting that can be set on the command line
 | <a id="string_list_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#string_list_setting"></a>
+<a id="string_list_setting"></a>
 
 ## string_list_setting
 
@@ -136,7 +136,7 @@ A string list-typed build setting that cannot be set on the command line
 | <a id="string_list_setting-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 
 
-<a id="#string_setting"></a>
+<a id="string_setting"></a>
 
 ## string_setting
 
@@ -155,7 +155,7 @@ A string-typed build setting that cannot be set on the command line
 | <a id="string_setting-values"></a>values |  The list of allowed values for this setting. An error is raised if any other value is given.   | List of strings | optional | [] |
 
 
-<a id="#BuildSettingInfo"></a>
+<a id="BuildSettingInfo"></a>
 
 ## BuildSettingInfo
 

--- a/docs/copy_directory_doc.md
+++ b/docs/copy_directory_doc.md
@@ -6,7 +6,7 @@ The rule uses a Bash command on Linux/macOS/non-Windows, and a cmd.exe command
 on Windows (no Bash is required).
 
 
-<a id="#copy_directory"></a>
+<a id="copy_directory"></a>
 
 ## copy_directory
 
@@ -36,7 +36,7 @@ for more context.
 | <a id="copy_directory-kwargs"></a>kwargs |  further keyword arguments, e.g. <code>visibility</code>   |  none |
 
 
-<a id="#copy_directory_action"></a>
+<a id="copy_directory_action"></a>
 
 ## copy_directory_action
 

--- a/docs/copy_file_doc.md
+++ b/docs/copy_file_doc.md
@@ -9,7 +9,7 @@ The rule uses a Bash command on Linux/macOS/non-Windows, and a cmd.exe command
 on Windows (no Bash is required).
 
 
-<a id="#copy_file"></a>
+<a id="copy_file"></a>
 
 ## copy_file
 

--- a/docs/dicts_doc.md
+++ b/docs/dicts_doc.md
@@ -2,7 +2,7 @@
 
 Skylib module containing functions that operate on dictionaries.
 
-<a id="#dicts.add"></a>
+<a id="dicts.add"></a>
 
 ## dicts.add
 
@@ -34,7 +34,7 @@ dictionary, and the sum of a single dictionary is a copy of itself.
 A new `dict` that has all the entries of the given dictionaries.
 
 
-<a id="#dicts.omit"></a>
+<a id="dicts.omit"></a>
 
 ## dicts.omit
 
@@ -57,7 +57,7 @@ Returns a new `dict` that has all the entries of `dictionary` with keys not in `
 A new `dict` that has all the entries of `dictionary` with keys not in `keys`.
 
 
-<a id="#dicts.pick"></a>
+<a id="dicts.pick"></a>
 
 ## dicts.pick
 

--- a/docs/diff_test_doc.md
+++ b/docs/diff_test_doc.md
@@ -6,7 +6,7 @@ The rule uses a Bash command (diff) on Linux/macOS/non-Windows, and a cmd.exe
 command (fc.exe) on Windows (no Bash is required).
 
 
-<a id="#diff_test"></a>
+<a id="diff_test"></a>
 
 ## diff_test
 

--- a/docs/expand_template_doc.md
+++ b/docs/expand_template_doc.md
@@ -3,7 +3,7 @@
 A rule that performes template expansion.
 
 
-<a id="#expand_template"></a>
+<a id="expand_template"></a>
 
 ## expand_template
 

--- a/docs/maintainers_guide.md
+++ b/docs/maintainers_guide.md
@@ -72,7 +72,8 @@ Name 1, Name 2, Name 3 (alphabetically from `git log`)
 
 --------------------------------------------------------------------------------
 
-2.  Bump `version` in version.bzl to the new version.
+2.  Bump `version` in version.bzl *and* MODULE.bazel to the new version.
+    TODO(#386): add a test to make sure the two versions are in sync.
 3.  Ensure that the commits for steps 1 and 2 have been merged. All further
     steps must be performed on a single, known-good git commit.
 4.  `bazel build //distribution:bazel-skylib-$VERSION.tar.gz`

--- a/docs/native_binary_doc.md
+++ b/docs/native_binary_doc.md
@@ -8,7 +8,7 @@ do, but they run the wrapped binary directly, instead of through Bash, so they
 don't depend on Bash and work with --shell_executable="".
 
 
-<a id="#native_binary"></a>
+<a id="native_binary"></a>
 
 ## native_binary
 
@@ -34,7 +34,7 @@ in genrule.tools for example. You can also augment the binary with runfiles.
 | <a id="native_binary-src"></a>src |  path of the pre-built executable   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 
 
-<a id="#native_test"></a>
+<a id="native_test"></a>
 
 ## native_test
 

--- a/docs/new_sets_doc.md
+++ b/docs/new_sets_doc.md
@@ -11,7 +11,7 @@ Skylib module containing common hash-set algorithms.
   `types.is_set()` method in types.bzl.
 
 
-<a id="#sets.make"></a>
+<a id="sets.make"></a>
 
 ## sets.make
 
@@ -36,7 +36,7 @@ All elements must be hashable.
 A set containing the passed in values.
 
 
-<a id="#sets.copy"></a>
+<a id="sets.copy"></a>
 
 ## sets.copy
 
@@ -58,7 +58,7 @@ Creates a new set from another set.
 A new set containing the same elements as `s`.
 
 
-<a id="#sets.to_list"></a>
+<a id="sets.to_list"></a>
 
 ## sets.to_list
 
@@ -80,7 +80,7 @@ Creates a list from the values in the set.
 A list of values inserted into the set.
 
 
-<a id="#sets.insert"></a>
+<a id="sets.insert"></a>
 
 ## sets.insert
 
@@ -106,7 +106,7 @@ Element must be hashable.  This mutates the original set.
 The set `s` with `e` included.
 
 
-<a id="#sets.contains"></a>
+<a id="sets.contains"></a>
 
 ## sets.contains
 
@@ -129,7 +129,7 @@ Checks for the existence of an element in a set.
 True if the element exists in the set, False if the element does not.
 
 
-<a id="#sets.is_equal"></a>
+<a id="sets.is_equal"></a>
 
 ## sets.is_equal
 
@@ -152,7 +152,7 @@ Returns whether two sets are equal.
 True if `a` is equal to `b`, False otherwise.
 
 
-<a id="#sets.is_subset"></a>
+<a id="sets.is_subset"></a>
 
 ## sets.is_subset
 
@@ -175,7 +175,7 @@ Returns whether `a` is a subset of `b`.
 True if `a` is a subset of `b`, False otherwise.
 
 
-<a id="#sets.disjoint"></a>
+<a id="sets.disjoint"></a>
 
 ## sets.disjoint
 
@@ -201,7 +201,7 @@ Two sets are disjoint if they have no elements in common.
 True if `a` and `b` are disjoint, False otherwise.
 
 
-<a id="#sets.intersection"></a>
+<a id="sets.intersection"></a>
 
 ## sets.intersection
 
@@ -224,7 +224,7 @@ Returns the intersection of two sets.
 A set containing the elements that are in both `a` and `b`.
 
 
-<a id="#sets.union"></a>
+<a id="sets.union"></a>
 
 ## sets.union
 
@@ -246,7 +246,7 @@ Returns the union of several sets.
 The set union of all sets in `*args`.
 
 
-<a id="#sets.difference"></a>
+<a id="sets.difference"></a>
 
 ## sets.difference
 
@@ -269,7 +269,7 @@ Returns the elements in `a` that are not in `b`.
 A set containing the elements that are in `a` but not in `b`.
 
 
-<a id="#sets.length"></a>
+<a id="sets.length"></a>
 
 ## sets.length
 
@@ -291,7 +291,7 @@ Returns the number of elements in a set.
 An integer representing the number of elements in the set.
 
 
-<a id="#sets.remove"></a>
+<a id="sets.remove"></a>
 
 ## sets.remove
 
@@ -317,7 +317,7 @@ Element must be hashable.  This mutates the original set.
 The set `s` with `e` removed.
 
 
-<a id="#sets.repr"></a>
+<a id="sets.repr"></a>
 
 ## sets.repr
 
@@ -339,7 +339,7 @@ Returns a string value representing the set.
 A string representing the set.
 
 
-<a id="#sets.str"></a>
+<a id="sets.str"></a>
 
 ## sets.str
 

--- a/docs/partial_doc.md
+++ b/docs/partial_doc.md
@@ -7,7 +7,7 @@ Partial function objects allow some parameters are bound before the call.
 Similar to https://docs.python.org/3/library/functools.html#functools.partial.
 
 
-<a id="#partial.make"></a>
+<a id="partial.make"></a>
 
 ## partial.make
 
@@ -123,7 +123,7 @@ partial.call(func, x=2)
 A new `partial` that can be called using `call`
 
 
-<a id="#partial.call"></a>
+<a id="partial.call"></a>
 
 ## partial.call
 
@@ -147,7 +147,7 @@ Calls a partial created using `make`.
 Whatever the function in the partial returns.
 
 
-<a id="#partial.is_instance"></a>
+<a id="partial.is_instance"></a>
 
 ## partial.is_instance
 

--- a/docs/paths_doc.md
+++ b/docs/paths_doc.md
@@ -7,7 +7,7 @@ path separators (forward slash, "/"); they do not handle Windows-style paths
 with backslash separators or drive letters.
 
 
-<a id="#paths.basename"></a>
+<a id="paths.basename"></a>
 
 ## paths.basename
 
@@ -35,7 +35,7 @@ the final slash).
 The basename of the path, which includes the extension.
 
 
-<a id="#paths.dirname"></a>
+<a id="paths.dirname"></a>
 
 ## paths.dirname
 
@@ -62,7 +62,7 @@ included, unless omitting them would make the dirname empty.
 The dirname of the path.
 
 
-<a id="#paths.is_absolute"></a>
+<a id="paths.is_absolute"></a>
 
 ## paths.is_absolute
 
@@ -84,7 +84,7 @@ Returns `True` if `path` is an absolute path.
 `True` if `path` is an absolute path.
 
 
-<a id="#paths.join"></a>
+<a id="paths.join"></a>
 
 ## paths.join
 
@@ -116,7 +116,7 @@ If any component is an absolute path, all previous components are discarded.
 A string containing the joined paths.
 
 
-<a id="#paths.normalize"></a>
+<a id="paths.normalize"></a>
 
 ## paths.normalize
 
@@ -153,7 +153,7 @@ POSIX platforms; specifically:
 The normalized path.
 
 
-<a id="#paths.relativize"></a>
+<a id="paths.relativize"></a>
 
 ## paths.relativize
 
@@ -185,7 +185,7 @@ the path both start with the same initial parent references.
 The portion of `path` that is relative to `start`.
 
 
-<a id="#paths.replace_extension"></a>
+<a id="paths.replace_extension"></a>
 
 ## paths.replace_extension
 
@@ -211,7 +211,7 @@ If the path has no extension, the new extension is added to it.
 The path with the extension replaced (or added, if it did not have one).
 
 
-<a id="#paths.split_extension"></a>
+<a id="paths.split_extension"></a>
 
 ## paths.split_extension
 

--- a/docs/run_binary_doc.md
+++ b/docs/run_binary_doc.md
@@ -6,7 +6,7 @@ run_binary() build rule implementation.
 Runs a binary as a build action. This rule does not require Bash (unlike native.genrule()).
 
 
-<a id="#run_binary"></a>
+<a id="run_binary"></a>
 
 ## run_binary
 

--- a/docs/selects_doc.md
+++ b/docs/selects_doc.md
@@ -2,7 +2,7 @@
 
 Skylib module containing convenience interfaces for select().
 
-<a id="#selects.with_or"></a>
+<a id="selects.with_or"></a>
 
 ## selects.with_or
 
@@ -48,7 +48,7 @@ to
 ```
 
 
-<a id="#selects.with_or_dict"></a>
+<a id="selects.with_or_dict"></a>
 
 ## selects.with_or_dict
 
@@ -74,7 +74,7 @@ macros.
 A dictionary usable by a native `select()`.
 
 
-<a id="#selects.config_setting_group"></a>
+<a id="selects.config_setting_group"></a>
 
 ## selects.config_setting_group
 

--- a/docs/shell_doc.md
+++ b/docs/shell_doc.md
@@ -2,7 +2,7 @@
 
 Skylib module containing shell utility functions.
 
-<a id="#shell.array_literal"></a>
+<a id="shell.array_literal"></a>
 
 ## shell.array_literal
 
@@ -33,7 +33,7 @@ A string that represents the sequence as a shell array; that is,
 parentheses containing the quoted elements.
 
 
-<a id="#shell.quote"></a>
+<a id="shell.quote"></a>
 
 ## shell.quote
 

--- a/docs/structs_doc.md
+++ b/docs/structs_doc.md
@@ -2,7 +2,7 @@
 
 Skylib module containing functions that operate on structs.
 
-<a id="#structs.to_dict"></a>
+<a id="structs.to_dict"></a>
 
 ## structs.to_dict
 

--- a/docs/subpackages_doc.md
+++ b/docs/subpackages_doc.md
@@ -3,7 +3,7 @@
 Skylib module containing common functions for working with native.subpackages()
 
 
-<a id="#subpackages.all"></a>
+<a id="subpackages.all"></a>
 
 ## subpackages.all
 
@@ -46,7 +46,7 @@ A mutable sorted list containing all sub-packages of the current Bazel
 package.
 
 
-<a id="#subpackages.exists"></a>
+<a id="subpackages.exists"></a>
 
 ## subpackages.exists
 
@@ -82,7 +82,7 @@ NOTE: fail()s if native.subpackages() is not supported in the current Bazel vers
 True if 'relative_path' is a subpackage of the current package.
 
 
-<a id="#subpackages.supported"></a>
+<a id="subpackages.supported"></a>
 
 ## subpackages.supported
 

--- a/docs/types_doc.md
+++ b/docs/types_doc.md
@@ -2,7 +2,7 @@
 
 Skylib module containing functions checking types.
 
-<a id="#types.is_list"></a>
+<a id="types.is_list"></a>
 
 ## types.is_list
 
@@ -24,7 +24,7 @@ Returns True if v is an instance of a list.
 True if v is an instance of a list, False otherwise.
 
 
-<a id="#types.is_string"></a>
+<a id="types.is_string"></a>
 
 ## types.is_string
 
@@ -46,7 +46,7 @@ Returns True if v is an instance of a string.
 True if v is an instance of a string, False otherwise.
 
 
-<a id="#types.is_bool"></a>
+<a id="types.is_bool"></a>
 
 ## types.is_bool
 
@@ -68,7 +68,7 @@ Returns True if v is an instance of a bool.
 True if v is an instance of a bool, False otherwise.
 
 
-<a id="#types.is_none"></a>
+<a id="types.is_none"></a>
 
 ## types.is_none
 
@@ -90,7 +90,7 @@ Returns True if v has the type of None.
 True if v is None, False otherwise.
 
 
-<a id="#types.is_int"></a>
+<a id="types.is_int"></a>
 
 ## types.is_int
 
@@ -112,7 +112,7 @@ Returns True if v is an instance of a signed integer.
 True if v is an instance of a signed integer, False otherwise.
 
 
-<a id="#types.is_tuple"></a>
+<a id="types.is_tuple"></a>
 
 ## types.is_tuple
 
@@ -134,7 +134,7 @@ Returns True if v is an instance of a tuple.
 True if v is an instance of a tuple, False otherwise.
 
 
-<a id="#types.is_dict"></a>
+<a id="types.is_dict"></a>
 
 ## types.is_dict
 
@@ -156,7 +156,7 @@ Returns True if v is an instance of a dict.
 True if v is an instance of a dict, False otherwise.
 
 
-<a id="#types.is_function"></a>
+<a id="types.is_function"></a>
 
 ## types.is_function
 
@@ -178,7 +178,7 @@ Returns True if v is an instance of a function.
 True if v is an instance of a function, False otherwise.
 
 
-<a id="#types.is_depset"></a>
+<a id="types.is_depset"></a>
 
 ## types.is_depset
 
@@ -200,7 +200,7 @@ Returns True if v is an instance of a `depset`.
 True if v is an instance of a `depset`, False otherwise.
 
 
-<a id="#types.is_set"></a>
+<a id="types.is_set"></a>
 
 ## types.is_set
 

--- a/docs/unittest_doc.md
+++ b/docs/unittest_doc.md
@@ -16,7 +16,7 @@ See https://bazel.build/extending/concepts for background about macros, rules,
 and the different phases of a build.
 
 
-<a id="#unittest_toolchain"></a>
+<a id="unittest_toolchain"></a>
 
 ## unittest_toolchain
 
@@ -41,7 +41,7 @@ unittest_toolchain(<a href="#unittest_toolchain-name">name</a>, <a href="#unitte
 | <a id="unittest_toolchain-success_templ"></a>success_templ |  Test script generated when the test passes. Should exit with status 0.   | String | required |  |
 
 
-<a id="#analysistest.make"></a>
+<a id="analysistest.make"></a>
 
 ## analysistest.make
 
@@ -95,7 +95,7 @@ A rule definition that should be stored in a global whose name ends in
 `_test`.
 
 
-<a id="#analysistest.begin"></a>
+<a id="analysistest.begin"></a>
 
 ## analysistest.begin
 
@@ -125,7 +125,7 @@ A test environment struct that must be passed to assertions and finally to
 struct as it may change.
 
 
-<a id="#analysistest.end"></a>
+<a id="analysistest.end"></a>
 
 ## analysistest.end
 
@@ -151,7 +151,7 @@ that the results are reported.
 A list of providers needed to automatically register the analysis test result.
 
 
-<a id="#analysistest.fail"></a>
+<a id="analysistest.fail"></a>
 
 ## analysistest.fail
 
@@ -170,7 +170,7 @@ Unconditionally causes the current test to fail.
 | <a id="analysistest.fail-msg"></a>msg |  The message to log describing the failure.   |  none |
 
 
-<a id="#analysistest.target_actions"></a>
+<a id="analysistest.target_actions"></a>
 
 ## analysistest.target_actions
 
@@ -192,7 +192,7 @@ Returns a list of actions registered by the target under test.
 A list of actions registered by the target under test
 
 
-<a id="#analysistest.target_bin_dir_path"></a>
+<a id="analysistest.target_bin_dir_path"></a>
 
 ## analysistest.target_bin_dir_path
 
@@ -214,7 +214,7 @@ Returns ctx.bin_dir.path for the target under test.
 Output bin dir path string.
 
 
-<a id="#analysistest.target_under_test"></a>
+<a id="analysistest.target_under_test"></a>
 
 ## analysistest.target_under_test
 
@@ -236,7 +236,7 @@ Returns the target under test.
 The target under test.
 
 
-<a id="#asserts.expect_failure"></a>
+<a id="asserts.expect_failure"></a>
 
 ## asserts.expect_failure
 
@@ -259,7 +259,7 @@ This requires that the analysis test is created with `analysistest.make()` and
 | <a id="asserts.expect_failure-expected_failure_msg"></a>expected_failure_msg |  The error message to expect as a result of analysis failures.   |  <code>""</code> |
 
 
-<a id="#asserts.equals"></a>
+<a id="asserts.equals"></a>
 
 ## asserts.equals
 
@@ -280,7 +280,7 @@ Asserts that the given `expected` and `actual` values are equal.
 | <a id="asserts.equals-msg"></a>msg |  An optional message that will be printed that describes the failure. If omitted, a default will be used.   |  <code>None</code> |
 
 
-<a id="#asserts.false"></a>
+<a id="asserts.false"></a>
 
 ## asserts.false
 
@@ -300,7 +300,7 @@ Asserts that the given `condition` is false.
 | <a id="asserts.false-msg"></a>msg |  An optional message that will be printed that describes the failure. If omitted, a default will be used.   |  <code>"Expected condition to be false, but was true."</code> |
 
 
-<a id="#asserts.set_equals"></a>
+<a id="asserts.set_equals"></a>
 
 ## asserts.set_equals
 
@@ -321,7 +321,7 @@ Asserts that the given `expected` and `actual` sets are equal.
 | <a id="asserts.set_equals-msg"></a>msg |  An optional message that will be printed that describes the failure. If omitted, a default will be used.   |  <code>None</code> |
 
 
-<a id="#asserts.new_set_equals"></a>
+<a id="asserts.new_set_equals"></a>
 
 ## asserts.new_set_equals
 
@@ -342,7 +342,7 @@ Asserts that the given `expected` and `actual` sets are equal.
 | <a id="asserts.new_set_equals-msg"></a>msg |  An optional message that will be printed that describes the failure. If omitted, a default will be used.   |  <code>None</code> |
 
 
-<a id="#asserts.true"></a>
+<a id="asserts.true"></a>
 
 ## asserts.true
 
@@ -362,7 +362,7 @@ Asserts that the given `condition` is true.
 | <a id="asserts.true-msg"></a>msg |  An optional message that will be printed that describes the failure. If omitted, a default will be used.   |  <code>"Expected condition to be true, but was false."</code> |
 
 
-<a id="#loadingtest.make"></a>
+<a id="loadingtest.make"></a>
 
 ## loadingtest.make
 
@@ -384,7 +384,7 @@ Creates a loading phase test environment and test_suite.
 loading phase environment passed to other loadingtest functions
 
 
-<a id="#loadingtest.equals"></a>
+<a id="loadingtest.equals"></a>
 
 ## loadingtest.equals
 
@@ -409,7 +409,7 @@ Creates a test case for asserting state at LOADING phase.
 None, creates test case
 
 
-<a id="#register_unittest_toolchains"></a>
+<a id="register_unittest_toolchains"></a>
 
 ## register_unittest_toolchains
 
@@ -421,7 +421,7 @@ Registers the toolchains for unittest users.
 
 
 
-<a id="#unittest.make"></a>
+<a id="unittest.make"></a>
 
 ## unittest.make
 
@@ -469,7 +469,7 @@ A rule definition that should be stored in a global whose name ends in
 `_test`.
 
 
-<a id="#unittest.suite"></a>
+<a id="unittest.suite"></a>
 
 ## unittest.suite
 
@@ -525,7 +525,7 @@ name each target.
 | <a id="unittest.suite-test_rules"></a>test_rules |  A list of test rules defines by <code>unittest.test</code>.   |  none |
 
 
-<a id="#unittest.begin"></a>
+<a id="unittest.begin"></a>
 
 ## unittest.begin
 
@@ -555,7 +555,7 @@ A test environment struct that must be passed to assertions and finally to
 struct as it may change.
 
 
-<a id="#unittest.end"></a>
+<a id="unittest.end"></a>
 
 ## unittest.end
 
@@ -581,7 +581,7 @@ that the results are reported.
 A list of providers needed to automatically register the test result.
 
 
-<a id="#unittest.fail"></a>
+<a id="unittest.fail"></a>
 
 ## unittest.fail
 

--- a/docs/versions_doc.md
+++ b/docs/versions_doc.md
@@ -2,7 +2,7 @@
 
 Skylib module containing functions for checking Bazel versions.
 
-<a id="#versions.get"></a>
+<a id="versions.get"></a>
 
 ## versions.get
 
@@ -14,7 +14,7 @@ Returns the current Bazel version
 
 
 
-<a id="#versions.parse"></a>
+<a id="versions.parse"></a>
 
 ## versions.parse
 
@@ -39,7 +39,7 @@ int tuples can be compared directly using binary operators (<, >).
 An int 3-tuple of a (major, minor, patch) version.
 
 
-<a id="#versions.check"></a>
+<a id="versions.check"></a>
 
 ## versions.check
 
@@ -59,7 +59,7 @@ Check that the version of Bazel is valid within the specified range.
 | <a id="versions.check-bazel_version"></a>bazel_version |  the version of Bazel to check. Used for testing, defaults to native.bazel_version   |  <code>None</code> |
 
 
-<a id="#versions.is_at_most"></a>
+<a id="versions.is_at_most"></a>
 
 ## versions.is_at_most
 
@@ -82,7 +82,7 @@ Check that a version is lower or equals to a threshold.
 True if version <= threshold.
 
 
-<a id="#versions.is_at_least"></a>
+<a id="versions.is_at_least"></a>
 
 ## versions.is_at_least
 

--- a/docs/write_file_doc.md
+++ b/docs/write_file_doc.md
@@ -10,7 +10,7 @@ file. Instead they use Starlark's built-in file writing action
 (ctx.actions.write).
 
 
-<a id="#write_file"></a>
+<a id="write_file"></a>
 
 ## write_file
 


### PR DESCRIPTION
Creates MODULE.bazel and WORKSPACE.bzlmod files to enable bazel-skylib
to work with the `--experimental_enable_bzlmod` flag.

rules_go has been updated as the previously used version is not
available in the BCR.

stardoc has been updated due to a strange issue with Bzlmod enabled that
caused the `diff_test` and `unittest` docs to be generated without any
contents that was magically fixed upon updating.

bazelbuild/bazel-central-registry#124