### PR TITLE
Add a version consistency check

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,3 +31,10 @@ use_repo(go_deps, "com_github_bazelbuild_buildtools")
 bazel_dep(name = "stardoc", dev_dependency = True, repo_name = "io_bazel_stardoc", version = "0.5.1")
 bazel_dep(name = "rules_pkg", dev_dependency = True, version = "0.5.1")
 bazel_dep(name = "rules_cc", dev_dependency = True, version = "0.0.1")
+
+# needed by buildozer
+go_deps.module(
+    path = "github.com/golang/protobuf",
+    sum = "h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=",
+    version = "v1.5.0",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -80,6 +80,28 @@ http_archive(
 # Another Gazelle repository hint.
 # gazelle:repository go_repository name=bazel_gazelle importpath=github.com/bazelbuild/bazel-gazelle/testtools
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
+
+# Buildozer & deps
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",
+    strip_prefix = "protobuf-3.19.2",
+    urls = [
+        "https://github.com/protocolbuffers/protobuf/archive/v3.19.2.tar.gz",
+    ],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+go_repository(
+    name = "com_github_bazelbuild_buildtools",
+    build_naming_convention = "go_default_library",
+    importpath = "github.com/bazelbuild/buildtools",
+    sum = "h1:fmdo+fvvWlhldUcqkhAMpKndSxMN3vH5l7yow5cEaiQ=",
+    version = "v0.0.0-20220531122519-a43aed7014c8"
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,4 +1,5 @@
 load("//:bzl_library.bzl", "bzl_library")
+load("//rules:diff_test.bzl", "diff_test")
 load(":build_test_tests.bzl", "build_test_test_suite")
 load(":collections_tests.bzl", "collections_test_suite")
 load(":dicts_tests.bzl", "dicts_test_suite")
@@ -99,4 +100,26 @@ shell_args_test_gen(
 sh_test(
     name = "shell_spawn_e2e_test",
     srcs = [":shell_spawn_e2e_test_src"],
+)
+
+genrule(
+    name = "version_from_module.bazel",
+    srcs = ["//:MODULE.bazel"],
+    outs = ["version_from_module.bazel.out"],
+    cmd = "cat '$<' | $(location @com_github_bazelbuild_buildtools//buildozer) 'print version' '-:bazel_skylib' > '$@'",
+    tools = ["@com_github_bazelbuild_buildtools//buildozer"],
+)
+
+genrule(
+    name = "version_from_version.bzl",
+    srcs = ["//:version.bzl"],
+    outs = ["version_from_version.bzl.out"],
+    cmd = "sed -n 's/ *version = \"\\(.*\\)\"/\\1/p' '$<' > '$@'",
+)
+
+diff_test(
+    name = "bazel_skylib_version_consistency_test",
+    failure_message = "The values of 'version' in version.bzl and MODULE.bazel do not match",
+    file1 = ":version_from_module.bazel",
+    file2 = ":version_from_version.bzl",
 )


### PR DESCRIPTION
Extract the version from version.bzl using sed.

For MODULE.bazel, we need to use buildifier to avoid confusion between skylib's version and our dependencies' versions.