### PR TITLE
Stop hardcoding runfiles prefix

### DIFF
--- a/tests/analysis_test_test.sh
+++ b/tests/analysis_test_test.sh
@@ -41,7 +41,7 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-source "$(rlocation bazel_skylib/tests/unittest.bash)" \
+source "$(rlocation $TEST_WORKSPACE/tests/unittest.bash)" \
   || { echo "Could not source bazel_skylib/tests/unittest.bash" >&2; exit 1; }
 
 function create_pkg() {
@@ -58,7 +58,7 @@ EOF
 exports_files(["*.bzl"])
 EOF
 
-  ln -sf "$(rlocation bazel_skylib/rules/analysis_test.bzl)" rules/analysis_test.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/rules/analysis_test.bzl)" rules/analysis_test.bzl
 
   mkdir -p fakerules
   cat > fakerules/rules.bzl <<EOF

--- a/tests/common_settings_test.sh
+++ b/tests/common_settings_test.sh
@@ -38,7 +38,7 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-source "$(rlocation bazel_skylib/tests/unittest.bash)" \
+source "$(rlocation $TEST_WORKSPACE/tests/unittest.bash)" \
   || { echo "Could not source bazel_skylib/tests/unittest.bash" >&2; exit 1; }
 
 function create_volcano_pkg() {
@@ -55,7 +55,7 @@ EOF
 exports_files(["*.bzl"])
 EOF
 
-  ln -sf "$(rlocation bazel_skylib/rules/common_settings.bzl)" rules/common_settings.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/rules/common_settings.bzl)" rules/common_settings.bzl
 
   mkdir -p volcano
   cat > volcano/rules.bzl <<EOF

--- a/tests/copy_directory/copy_directory_tests.sh
+++ b/tests/copy_directory/copy_directory_tests.sh
@@ -37,43 +37,43 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-source "$(rlocation bazel_skylib/tests/unittest.bash)" \
+source "$(rlocation $TEST_WORKSPACE/tests/unittest.bash)" \
   || { echo "Could not source bazel_skylib/tests/unittest.bash" >&2; exit 1; }
 
 function test_copy_dir_with_subdir__copies_a() {
-  cat "$(rlocation bazel_skylib/tests/copy_directory/dir_copy)/a" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_directory/dir_copy)/a" >"$TEST_log"
   expect_log '^foo$'
 }
 
 function test_copy_dir_with_subdir__copies_b() {
-  cat "$(rlocation bazel_skylib/tests/copy_directory/dir_copy)/b" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_directory/dir_copy)/b" >"$TEST_log"
   expect_log '^bar$'
 }
 
 function test_copy_dir_with_subdir__copies_c() {
-  cat "$(rlocation bazel_skylib/tests/copy_directory/dir_copy)/subdir/c" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_directory/dir_copy)/subdir/c" >"$TEST_log"
   expect_log '^moocow$'
 }
 
 function test_copy_dir_with_subdir__correct_filecounts() {
-  local -r dir_filecount=$(ls "$(rlocation bazel_skylib/tests/copy_directory/dir_copy)" | wc -l)
+  local -r dir_filecount=$(ls "$(rlocation $TEST_WORKSPACE/tests/copy_directory/dir_copy)" | wc -l)
   assert_equals $dir_filecount 3
-  local -r subdir_filecount=$(ls "$(rlocation bazel_skylib/tests/copy_directory/dir_copy)/subdir" | wc -l)
+  local -r subdir_filecount=$(ls "$(rlocation $TEST_WORKSPACE/tests/copy_directory/dir_copy)/subdir" | wc -l)
   assert_equals $subdir_filecount 1
 }
 
 function test_copy_empty_dir() {
-  local -r filecount=$(ls "$(rlocation bazel_skylib/tests/copy_directory/empty_dir_copy)" | wc -l)
+  local -r filecount=$(ls "$(rlocation $TEST_WORKSPACE/tests/copy_directory/empty_dir_copy)" | wc -l)
   assert_equals $filecount 0
 }
 
 function test_copy_dir_with_symlink__copies_file() {
-  cat "$(rlocation bazel_skylib/tests/copy_directory/dir_with_symlink_copy)/file" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_directory/dir_with_symlink_copy)/file" >"$TEST_log"
   expect_log '^foo$'
 }
 
 function test_copy_dir_with_symlink__copies_symlink() {
-  cat "$(rlocation bazel_skylib/tests/copy_directory/dir_with_symlink_copy)/symlink" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_directory/dir_with_symlink_copy)/symlink" >"$TEST_log"
   expect_log '^foo$'
 }
 

--- a/tests/copy_file/copy_file_tests.sh
+++ b/tests/copy_file/copy_file_tests.sh
@@ -37,50 +37,50 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-source "$(rlocation bazel_skylib/tests/unittest.bash)" \
+source "$(rlocation $TEST_WORKSPACE/tests/unittest.bash)" \
   || { echo "Could not source bazel_skylib/tests/unittest.bash" >&2; exit 1; }
 
 function test_copy_src() {
-  cat "$(rlocation bazel_skylib/tests/copy_file/out/a-out.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_file/out/a-out.txt)" >"$TEST_log"
   expect_log '^#!/usr/bin/env bash$'
   expect_log '^echo aaa$'
 }
 
 function test_copy_src_symlink() {
-  cat "$(rlocation bazel_skylib/tests/copy_file/out/a-out-symlink.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_file/out/a-out-symlink.txt)" >"$TEST_log"
   expect_log '^#!/usr/bin/env bash$'
   expect_log '^echo aaa$'
 }
 
 function test_copy_gen() {
-  cat "$(rlocation bazel_skylib/tests/copy_file/out/gen-out.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_file/out/gen-out.txt)" >"$TEST_log"
   expect_log '^#!/usr/bin/env bash$'
   expect_log '^echo potato$'
 }
 
 function test_copy_gen_symlink() {
-  cat "$(rlocation bazel_skylib/tests/copy_file/out/gen-out-symlink.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_file/out/gen-out-symlink.txt)" >"$TEST_log"
   expect_log '^#!/usr/bin/env bash$'
   expect_log '^echo potato$'
 }
 
 function test_copy_xsrc() {
-  cat "$(rlocation bazel_skylib/tests/copy_file/xsrc-out.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_file/xsrc-out.txt)" >"$TEST_log"
   expect_log '^aaa$'
 }
 
 function test_copy_xsrc_symlink() {
-  cat "$(rlocation bazel_skylib/tests/copy_file/xsrc-out-symlink.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_file/xsrc-out-symlink.txt)" >"$TEST_log"
   expect_log '^aaa$'
 }
 
 function test_copy_xgen() {
-  cat "$(rlocation bazel_skylib/tests/copy_file/xgen-out.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_file/xgen-out.txt)" >"$TEST_log"
   expect_log '^potato$'
 }
 
 function test_copy_xgen_symlink() {
-  cat "$(rlocation bazel_skylib/tests/copy_file/xgen-out-symlink.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/copy_file/xgen-out-symlink.txt)" >"$TEST_log"
   expect_log '^potato$'
 }
 

--- a/tests/diff_test/diff_test_tests.sh
+++ b/tests/diff_test/diff_test_tests.sh
@@ -37,7 +37,7 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-source "$(rlocation bazel_skylib/tests/unittest.bash)" \
+source "$(rlocation $TEST_WORKSPACE/tests/unittest.bash)" \
   || { echo "Could not source bazel_skylib/tests/unittest.bash" >&2; exit 1; }
 
 function import_diff_test() {
@@ -46,9 +46,9 @@ function import_diff_test() {
   mkdir -p "${repo}/lib"
   touch "${repo}/lib/BUILD"
   touch "${repo}/WORKSPACE"
-  ln -sf "$(rlocation bazel_skylib/rules/diff_test.bzl)" \
+  ln -sf "$(rlocation $TEST_WORKSPACE/rules/diff_test.bzl)" \
          "${repo}/rules/diff_test.bzl"
-  ln -sf "$(rlocation bazel_skylib/lib/shell.bzl)" \
+  ln -sf "$(rlocation $TEST_WORKSPACE/lib/shell.bzl)" \
          "${repo}/lib/shell.bzl"
   echo "exports_files(['diff_test.bzl'])" > "${repo}/rules/BUILD"
 }

--- a/tests/expand_template/template_test.sh
+++ b/tests/expand_template/template_test.sh
@@ -25,11 +25,11 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
     { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
 # --- end runfiles.bash initialization v2 ---
 
-source "$(rlocation bazel_skylib/tests/unittest.bash)" \
+source "$(rlocation $TEST_WORKSPACE/tests/unittest.bash)" \
   || { echo "Could not source bazel_skylib/tests/unittest.bash" >&2; exit 1; }
 
 function test_expand_template() {
-  cat "$(rlocation bazel_skylib/tests/expand_template/foo/test.yaml)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/expand_template/foo/test.yaml)" >"$TEST_log"
   expect_log 'name: test'
   expect_log 'version: 1.1.1'
 }

--- a/tests/native_binary/assertdata.cc
+++ b/tests/native_binary/assertdata.cc
@@ -30,10 +30,17 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  char* workspace = getenv("TEST_WORKSPACE");
+  if (workspace == nullptr) {
+    fprintf(stderr, "ERROR(" __FILE__ ":%d): envvar TEST_WORKSPACE is undefined\n",
+            __LINE__);
+    return 1;
+  }
+
   // This should have runfiles, either from the binary itself or from the
   // native_test.
   std::string path =
-      runfiles->Rlocation("bazel_skylib/tests/native_binary/testdata.txt");
+      runfiles->Rlocation(std::string(workspace) + "/tests/native_binary/testdata.txt");
   FILE *f = fopen(path.c_str(), "rt");
   if (!f) {
     fprintf(stderr, "ERROR(" __FILE__ ":%d): Could not find runfile '%s'\n",

--- a/tests/unittest_test.sh
+++ b/tests/unittest_test.sh
@@ -42,7 +42,7 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-source "$(rlocation bazel_skylib/tests/unittest.bash)" \
+source "$(rlocation $TEST_WORKSPACE/tests/unittest.bash)" \
   || { echo "Could not source bazel_skylib/tests/unittest.bash" >&2; exit 1; }
 
 function create_pkg() {
@@ -64,22 +64,22 @@ EOF
   cat > tests/BUILD <<EOF
 exports_files(["*.bzl"])
 EOF
-  ln -sf "$(rlocation bazel_skylib/tests/unittest_tests.bzl)" tests/unittest_tests.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/tests/unittest_tests.bzl)" tests/unittest_tests.bzl
 
   mkdir -p lib
   touch lib/BUILD
   cat > lib/BUILD <<EOF
 exports_files(["*.bzl"])
 EOF
-  ln -sf "$(rlocation bazel_skylib/lib/dicts.bzl)" lib/dicts.bzl
-  ln -sf "$(rlocation bazel_skylib/lib/new_sets.bzl)" lib/new_sets.bzl
-  ln -sf "$(rlocation bazel_skylib/lib/partial.bzl)" lib/partial.bzl
-  ln -sf "$(rlocation bazel_skylib/lib/sets.bzl)" lib/sets.bzl
-  ln -sf "$(rlocation bazel_skylib/lib/types.bzl)" lib/types.bzl
-  ln -sf "$(rlocation bazel_skylib/lib/unittest.bzl)" lib/unittest.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/lib/dicts.bzl)" lib/dicts.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/lib/new_sets.bzl)" lib/new_sets.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/lib/partial.bzl)" lib/partial.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/lib/sets.bzl)" lib/sets.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/lib/types.bzl)" lib/types.bzl
+  ln -sf "$(rlocation $TEST_WORKSPACE/lib/unittest.bzl)" lib/unittest.bzl
 
   mkdir -p toolchains/unittest
-  ln -sf "$(rlocation bazel_skylib/toolchains/unittest/BUILD)" toolchains/unittest/BUILD
+  ln -sf "$(rlocation $TEST_WORKSPACE/toolchains/unittest/BUILD)" toolchains/unittest/BUILD
 
   # Create test files.
   mkdir -p testdir

--- a/tests/write_file/write_file_tests.sh
+++ b/tests/write_file/write_file_tests.sh
@@ -37,7 +37,7 @@ else
 fi
 # --- end runfiles.bash initialization ---
 
-source "$(rlocation bazel_skylib/tests/unittest.bash)" \
+source "$(rlocation $TEST_WORKSPACE/tests/unittest.bash)" \
   || { echo "Could not source bazel_skylib/tests/unittest.bash" >&2; exit 1; }
 
 function assert_empty_file() {
@@ -47,21 +47,21 @@ function assert_empty_file() {
 }
 
 function test_write_empty_text() {
-  assert_empty_file "$(rlocation bazel_skylib/tests/write_file/out/empty.txt)"
+  assert_empty_file "$(rlocation $TEST_WORKSPACE/tests/write_file/out/empty.txt)"
 }
 
 function test_write_nonempty_text() {
-  cat "$(rlocation bazel_skylib/tests/write_file/out/nonempty.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/write_file/out/nonempty.txt)" >"$TEST_log"
   expect_log '^aaa'
   expect_log '^bbb'
 }
 
 function test_write_empty_bin() {
-  assert_empty_file "$(rlocation bazel_skylib/tests/write_file/empty-bin-out.txt)"
+  assert_empty_file "$(rlocation $TEST_WORKSPACE/tests/write_file/empty-bin-out.txt)"
 }
 
 function test_write_nonempty_bin() {
-  cat "$(rlocation bazel_skylib/tests/write_file/nonempty-bin-out.txt)" >"$TEST_log"
+  cat "$(rlocation $TEST_WORKSPACE/tests/write_file/nonempty-bin-out.txt)" >"$TEST_log"
   expect_log '^potato'
 }
 


### PR DESCRIPTION
bazelbuild/bazel@6a8ddb7 changed the prefix for runfiles from the main repo when Bzlmod is enabled. Because all uses of rlocation were hardcoded to use "bazel_skylib", tests requiring runfiles stopped working with Bzlmod enabled. This commit updates calls to rlocation to instead use the TEST_WORKSPACE env var to get the repo name.