### PR TITLE
Update rules_go to fix build with bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ bazel_dep(name = "platforms", version = "0.0.4")
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
 
 # Gazelle extension is experimental
-bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.33.0")
+bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.35.0")
 bazel_dep(name = "gazelle", repo_name = "bazel_gazelle", version = "0.26.0")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,10 +6,10 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 maybe(
     name = "io_bazel_rules_go",
     repo_rule = http_archive,
-    sha256 = "685052b498b6ddfe562ca7a97736741d87916fe536623afb7da2824c0211c369",
+    sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.33.0/rules_go-v0.33.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
     ],
 )
 


### PR DESCRIPTION
Since bazelbuild/bazel@3f92232, rules_go v0.33.0 has been broken with bzlmod due to missing @com_github_golang_mock repository