### PR TITLE
Stop registering a Go SDK in the Gazelle submodule

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -9,17 +9,6 @@ bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "gazelle", repo_name = "bazel_gazelle", version = "0.28.0")
 bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.35.0")
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-
-go_sdk.download(
-    name = "go_sdk",
-    version = "1.18",
-)
-
-use_repo(go_sdk, "go_sdk")
-
-register_toolchains("@go_sdk//:all")
-
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 
 go_deps.module(

--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -9,6 +9,8 @@ bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "gazelle", repo_name = "bazel_gazelle", version = "0.28.0")
 bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.35.0")
 
+# `rules_go` will register a toolchain for us if the user doesn't do so
+
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 
 go_deps.module(


### PR DESCRIPTION
I'm not sure if this is the best way to solve this problem, but there are two cases where we want to use this repo:

1/ We're developing the repo itself. We should be responsible for
   registering the Go toolchain.

2/ We're being used transitively by another module (eg.
   `contrib_rules_jvm`. We should _not_ be responsible for
   registering the Go toolchain

Now, in the ideal world, we'd declare the Go SDK as a dev dependency, and everything would be fine. However, we can't do this because there's no way to gate the call to `register_toolchain` on us being the root module or not.

The workaround? Attempt to use a unique name for the Go SDK that we need and hope that this works as we think it does.