### PR TITLE
Attempt to fix #416

### DIFF
--- a/lib/selects.bzl
+++ b/lib/selects.bzl
@@ -138,7 +138,7 @@ def _remove_default_condition(settings):
     """Returns settings with "//conditions:default" entries filtered out."""
     new_settings = []
     for setting in settings:
-        if settings != "//conditions:default":
+        if setting != "//conditions:default":
             new_settings.append(setting)
     return new_settings
 

--- a/tests/selects_tests.bzl
+++ b/tests/selects_tests.bzl
@@ -90,12 +90,26 @@ def _create_config_setting_groups():
         match_all = [":condition1"],
     )
     selects.config_setting_group(
+        name = "always_true_all",
+        match_all = ["//conditions:default"],
+    )
+    selects.config_setting_group(
         name = "1_or_2_or_3",
         match_any = [":condition1", ":condition2", ":condition3"],
     )
     selects.config_setting_group(
         name = "1_or_nothing_else",
         match_any = [":condition1"],
+    )
+
+    # Can't create config setting group which has //conditions:default in it.
+    selects.config_setting_group(
+        name = "always_true_regardless_of_1",
+        match_any = ["//conditions:default", ":condition1"],
+    )
+    selects.config_setting_group(
+        name = "always_true_any",
+        match_any = ["//conditions:default"],
     )
 
 ###################################################
@@ -178,6 +192,22 @@ def _and_config_setting_group_matches_test():
     and_config_setting_group_matches_test(
         name = "and_config_setting_group_matches_test",
         target_under_test = ":and_config_setting_group_matches_rule",
+    )
+
+def _and_config_setting_group_always_true_test():
+    """Test verifying match on an ANDing config_setting_group."""
+    boolean_attr_rule(
+        name = "and_config_setting_group_always_true_rule",
+        myboolean = select(
+            {
+                ":always_true_all": True,
+                "//conditions:default": False,
+            },
+        ),
+    )
+    and_config_setting_group_matches_test(
+        name = "and_config_setting_group_always_true_test",
+        target_under_test = ":and_config_setting_group_always_true_rule",
     )
 
 ###################################################
@@ -619,6 +649,7 @@ def selects_test_suite():
     _create_config_setting_groups()
 
     _and_config_setting_group_matches_test()
+    _and_config_setting_group_always_true_test()
     _and_config_setting_group_first_match_fails_test()
     _and_config_setting_group_middle_match_fails_test()
     _and_config_setting_group_last_match_fails_test()


### PR DESCRIPTION
DO NOT merge this patch yet.  

Fixing the typo exposes a more serious issue -- there's a recursion across function calls in the selects.bzl:

```
ERROR: Traceback (most recent call last):
        File "bazel-skylib/tests/BUILD", line 35, column 19, in <toplevel>
                selects_test_suite()
        File "bazel-skylib/tests/selects_tests.bzl", line 649, column 34, in selects_test_suite
                _create_config_setting_groups()
        File "bazel-skylib/tests/selects_tests.bzl", line 106, column 33, in _create_config_setting_groups
                selects.config_setting_group(
        File "bazel-skylib/lib/selects.bzl", line 125, column 33, in _config_setting_group
                _config_setting_or_group(name, match_any, visibility)
        File "bazel-skylib/lib/selects.bzl", line 158, column 36, in _config_setting_or_group
                _config_setting_always_true(name, visibility)
        File "bazel-skylib/lib/selects.bzl", line 243, column 36, in _config_setting_always_true
                return _config_setting_or_group(name, [":" + name_on, ":" + name_off], visibility)
        File "bazel-skylib/lib/selects.bzl", line 145, column 5, in _config_setting_or_group
                def _config_setting_or_group(name, settings, visibility):
Error: function '_config_setting_or_group' called recursively
ERROR: error loading package 'tests': Package 'tests' contains errors
```

This needs to be sorted out.

@gregestren -- This is resurrected cl/276532271 that I've never got to fix.
