### PR TITLE
Add gazelle plugin to CI and distribution mechanism

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,47 +1,44 @@
 ---
+.reusable_config: &reusable_config
+  build_targets:
+    - "--"
+    - "//..."
+    - "@bazel_skylib_gazelle_plugin//..."
+  test_targets:
+    - "--"
+    - "//..."
+    - "@bazel_skylib_gazelle_plugin//..."
+
 tasks:
   ubuntu1804_latest:
+    <<: *reusable_config
     name: "Latest Bazel"
     platform: ubuntu1804
     bazel: latest
-    build_targets:
-    - "//..."
-    test_targets:
-    - "//..."
     test_flags:
     - "--test_env=PATH"
 
   ubuntu1604_latest:
+    <<: *reusable_config
     name: "Latest Bazel"
     platform: ubuntu1604
     bazel: latest
-    build_targets:
-    - "//..."
-    test_targets:
-    - "//..."
     test_flags:
     - "--test_env=PATH"
 
   macos_latest:
+    <<: *reusable_config
     name: "Latest Bazel"
     platform: macos
     bazel: latest
-    build_targets:
-    - "//..."
-    test_targets:
-    - "//..."
     test_flags:
     - "--test_env=PATH"
 
   windows_latest:
+    <<: *reusable_config
     name: "Latest Bazel"
     platform: windows
     bazel: latest
-    build_targets:
-    - "//..."
-    test_targets:
-    - "--"
-    - "//..."
     test_flags:
     # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
     # https://github.com/bazelbuild/bazel/issues/7761 is fixed
@@ -49,47 +46,34 @@ tasks:
     - "--test_tag_filters=-no_windows"
 
   ubuntu1804_last_green:
+    <<: *reusable_config
     name: "Last Green Bazel"
     platform: ubuntu1804
     bazel: last_green
-    build_targets:
-    - "//..."
-    test_targets:
-    - "//..."
     test_flags:
     - "--test_env=PATH"
 
   ubuntu1604_last_green:
+    <<: *reusable_config
     name: "Last Green Bazel"
     platform: ubuntu1604
     bazel: last_green
-    build_targets:
-    - "//..."
-    test_targets:
-    - "//..."
     test_flags:
     - "--test_env=PATH"
 
   macos_last_green:
+    <<: *reusable_config
     name: "Last Green Bazel"
     platform: macos
     bazel: last_green
-    build_targets:
-    - "//..."
-    test_targets:
-    - "//..."
     test_flags:
     - "--test_env=PATH"
 
   windows_last_green:
+    <<: *reusable_config
     name: "Last Green Bazel"
     platform: windows
     bazel: last_green
-    build_targets:
-    - "//..."
-    test_targets:
-    - "--"
-    - "//..."
     test_flags:
     # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
     # https://github.com/bazelbuild/bazel/issues/7761 is fixed
@@ -97,13 +81,10 @@ tasks:
     - "--test_tag_filters=-no_windows"
 
   ubuntu1804_last_green_bzlmod:
+    <<: *reusable_config
     name: "Last Green Bazel (with bzlmod)"
     platform: ubuntu1804
     bazel: last_green
-    build_targets:
-    - "//..."
-    test_targets:
-    - "//..."
     build_flags:
       - "--experimental_enable_bzlmod"
     test_flags:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,8 @@
 module(
     name = "bazel_skylib",
-    compatibility_level = 1,
     # Keep in sync with version.bzl and @bazel_skylib_gazelle_plugin//:MODULE.bazel
     version = "1.3.0",
+    compatibility_level = 1,
 )
 
 register_toolchains(
@@ -15,6 +15,6 @@ bazel_dep(name = "platforms", version = "0.0.4")
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
 
 # Build-only / test-only dependencies
-bazel_dep(name = "stardoc", dev_dependency = True, repo_name = "io_bazel_stardoc", version = "0.5.3")
-bazel_dep(name = "rules_pkg", dev_dependency = True, version = "0.5.1")
-bazel_dep(name = "rules_cc", dev_dependency = True, version = "0.0.2")
+bazel_dep(name = "stardoc", version = "0.5.3", dev_dependency = True, repo_name = "io_bazel_stardoc")
+bazel_dep(name = "rules_pkg", version = "0.5.1", dev_dependency = True)
+bazel_dep(name = "rules_cc", version = "0.0.2", dev_dependency = True)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "platforms", version = "0.0.4")
 
 # Build-only / test-only dependencies
 bazel_dep(name = "stardoc", version = "0.5.3", dev_dependency = True, repo_name = "io_bazel_stardoc")
-bazel_dep(name = "rules_pkg", version = "0.5.1", dev_dependency = True)
+bazel_dep(name = "rules_pkg", version = "0.7.0", dev_dependency = True)
 bazel_dep(name = "rules_cc", version = "0.0.2", dev_dependency = True)
 
 # Needed for bazelci and for building distribution tarballs.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "rules_pkg", version = "0.7.0", dev_dependency = True)
 bazel_dep(name = "rules_cc", version = "0.0.2", dev_dependency = True)
 
 # Needed for bazelci and for building distribution tarballs.
-# Comment out the following if importing an unreleased version of bazel_skylib
-# as a dep via git_override:
+# If using an unreleased version of bazel_skylib via git_override, apply
+# MODULE.bazel-remove-override.patch to remove the following lines:
 bazel_dep(name = "bazel_skylib_gazelle_plugin", dev_dependency = True)
 local_path_override(module_name = "bazel_skylib_gazelle_plugin", path = "gazelle")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,4 +23,7 @@ bazel_dep(name = "rules_cc", version = "0.0.2", dev_dependency = True)
 # If using an unreleased version of bazel_skylib via git_override, apply
 # MODULE.bazel-remove-override.patch to remove the following lines:
 bazel_dep(name = "bazel_skylib_gazelle_plugin", dev_dependency = True)
-local_path_override(module_name = "bazel_skylib_gazelle_plugin", path = "gazelle")
+local_path_override(
+    module_name = "bazel_skylib_gazelle_plugin",
+    path = "gazelle",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "bazel_skylib",
     compatibility_level = 1,
-    # If you change this, please also update @bazel_skylib_gazelle_plugin//:MODULE.bazel
+    # Keep in sync with version.bzl and @bazel_skylib_gazelle_plugin//:MODULE.bazel
     version = "1.3.0",
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,3 +18,9 @@ bazel_dep(name = "platforms", version = "0.0.4")
 bazel_dep(name = "stardoc", version = "0.5.3", dev_dependency = True, repo_name = "io_bazel_stardoc")
 bazel_dep(name = "rules_pkg", version = "0.5.1", dev_dependency = True)
 bazel_dep(name = "rules_cc", version = "0.0.2", dev_dependency = True)
+
+# Needed for bazelci and for building distribution tarballs.
+# Comment out the following if importing an unreleased version of bazel_skylib
+# as a dep via git_override:
+bazel_dep(name = "bazel_skylib_gazelle_plugin", dev_dependency = True)
+local_path_override(module_name = "bazel_skylib_gazelle_plugin", path = "gazelle")

--- a/MODULE.bazel-remove-override.patch
+++ b/MODULE.bazel-remove-override.patch
@@ -1,0 +1,10 @@
+--- MODULE.bazel
++++ MODULE.bazel
+@@ -22,5 +22,5 @@
+ # Needed for bazelci and for building distribution tarballs.
+ # If using an unreleased version of bazel_skylib via git_override, apply
+ # MODULE.bazel-remove-override.patch to remove the following lines:
+-bazel_dep(name = "bazel_skylib_gazelle_plugin", dev_dependency = True)
+-local_path_override(module_name = "bazel_skylib_gazelle_plugin", path = "gazelle")
++# bazel_dep(name = "bazel_skylib_gazelle_plugin", dev_dependency = True)
++# local_path_override(module_name = "bazel_skylib_gazelle_plugin", path = "gazelle")

--- a/MODULE.bazel-remove-override.patch
+++ b/MODULE.bazel-remove-override.patch
@@ -1,10 +1,16 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -22,5 +22,5 @@
+@@ -22,8 +22,8 @@
  # Needed for bazelci and for building distribution tarballs.
  # If using an unreleased version of bazel_skylib via git_override, apply
  # MODULE.bazel-remove-override.patch to remove the following lines:
 -bazel_dep(name = "bazel_skylib_gazelle_plugin", dev_dependency = True)
--local_path_override(module_name = "bazel_skylib_gazelle_plugin", path = "gazelle")
+-local_path_override(
+-    module_name = "bazel_skylib_gazelle_plugin",
+-    path = "gazelle",
+-)
 +# bazel_dep(name = "bazel_skylib_gazelle_plugin", dev_dependency = True)
-+# local_path_override(module_name = "bazel_skylib_gazelle_plugin", path = "gazelle")
++# local_path_override(
++#     module_name = "bazel_skylib_gazelle_plugin",
++#     path = "gazelle",
++# )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,10 +40,10 @@ stardoc_repositories()
 maybe(
     http_archive,
     name = "rules_pkg",
-    sha256 = "a89e203d3cf264e564fcb96b6e06dd70bc0557356eb48400ce4b5d97c2c3720d",
+    sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.5.1/rules_pkg-0.5.1.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
     ],
 )
 

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:version.bzl", "version")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@rules_pkg//releasing:defs.bzl", "print_rel_notes")
+load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
 
 package(
     default_visibility = ["//visibility:private"],
@@ -15,7 +15,8 @@ genrule(
 
 # Build the artifacts to put on the github release page.
 pkg_tar(
-    name = "bazel-skylib-%s" % version,
+    name = "bazel-skylib",
+    out = "bazel-skylib-%s.tar.gz" % version,
     srcs = [
         "distro_module_bazel",
         "//:distribution",
@@ -24,30 +25,29 @@ pkg_tar(
     mode = "0644",
     # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",
-    strip_prefix = ".",
+    strip_prefix = strip_prefix.from_root(),
 )
 
-alias(
-    name = "bazel-skylib",
-    actual = "bazel-skylib-%s" % version,
-)
-
-pkg_tar(
-    name = "bazel-skylib-gazelle-plugin-%s" % version,
+pkg_files(
+    name = "bazel-skylib-gazelle-plugin-without-external-prefix",
     srcs = [
         "@bazel_skylib_gazelle_plugin//:distribution",
         "@bazel_skylib_gazelle_plugin//bzl:distribution",
+    ],
+    strip_prefix = strip_prefix.from_root(),
+)
+
+pkg_tar(
+    name = "bazel-skylib-gazelle-plugin",
+    out = "bazel-skylib-gazelle-plugin-%s.tar.gz" % version,
+    srcs = [
+        "//:LICENSE",
+        ":bazel-skylib-gazelle-plugin-without-external-prefix",
     ],
     extension = "tar.gz",
     mode = "0644",
     # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",
-    strip_prefix = ".",
-)
-
-alias(
-    name = "bazel-skylib-gazelle-plugin",
-    actual = "bazel-skylib-gazelle-plugin-%s" % version,
 )
 
 filegroup(
@@ -56,13 +56,4 @@ filegroup(
         "bazel-skylib",
         "bazel-skylib-gazelle-plugin",
     ],
-)
-
-print_rel_notes(
-    name = "relnotes",
-    outs = ["relnotes.txt"],
-    deps_method = "bazel_skylib_workspace",
-    repo = "bazel-skylib",
-    setup_file = ":workspace.bzl",
-    version = version,
 )

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -13,7 +13,7 @@ genrule(
     cmd = "sed -e '/### INTERNAL ONLY/,$$d' $(location //:MODULE.bazel) >$@",
 )
 
-# Build the artifact to put on the github release page.
+# Build the artifacts to put on the github release page.
 pkg_tar(
     name = "bazel-skylib-%s" % version,
     srcs = [
@@ -25,6 +25,37 @@ pkg_tar(
     # Make it owned by root so it does not have the uid of the CI robot.
     owner = "0.0",
     strip_prefix = ".",
+)
+
+alias(
+    name = "bazel-skylib",
+    actual = "bazel-skylib-%s" % version,
+)
+
+pkg_tar(
+    name = "bazel-skylib-gazelle-plugin-%s" % version,
+    srcs = [
+        "@bazel_skylib_gazelle_plugin//:distribution",
+        "@bazel_skylib_gazelle_plugin//bzl:distribution",
+    ],
+    extension = "tar.gz",
+    mode = "0644",
+    # Make it owned by root so it does not have the uid of the CI robot.
+    owner = "0.0",
+    strip_prefix = ".",
+)
+
+alias(
+    name = "bazel-skylib-gazelle-plugin",
+    actual = "bazel-skylib-gazelle-plugin-%s" % version,
+)
+
+filegroup(
+    name = "distribution",
+    srcs = [
+        "bazel-skylib",
+        "bazel-skylib-gazelle-plugin",
+    ],
 )
 
 print_rel_notes(

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -16,11 +16,11 @@ genrule(
 # Build the artifacts to put on the github release page.
 pkg_tar(
     name = "bazel-skylib",
-    out = "bazel-skylib-%s.tar.gz" % version,
     srcs = [
         "distro_module_bazel",
         "//:distribution",
     ],
+    out = "bazel-skylib-%s.tar.gz" % version,
     extension = "tar.gz",
     mode = "0644",
     # Make it owned by root so it does not have the uid of the CI robot.
@@ -39,11 +39,11 @@ pkg_files(
 
 pkg_tar(
     name = "bazel-skylib-gazelle-plugin",
-    out = "bazel-skylib-gazelle-plugin-%s.tar.gz" % version,
     srcs = [
-        "//:LICENSE",
         ":bazel-skylib-gazelle-plugin-without-external-prefix",
+        "//:LICENSE",
     ],
+    out = "bazel-skylib-gazelle-plugin-%s.tar.gz" % version,
     extension = "tar.gz",
     mode = "0644",
     # Make it owned by root so it does not have the uid of the CI robot.

--- a/docs/maintainers_guide.md
+++ b/docs/maintainers_guide.md
@@ -84,8 +84,8 @@ Name 1, Name 2, Name 3 (alphabetically from `git log`)
     you can obtain them via `gcloud init`):
 
 ```bash
-gsutil cp bazel-bin/distribution/bazel-skylib-$VERSION.tar.gz gs://bazel-mirror/github.com/bazelbuild/bazel-skylib/releases/download/$VERSION/bazel-skylib-$VERSION.tar.gz
-gsutil setmeta -h "Cache-Control: public, max-age=31536000" "gs://bazel-mirror/github.com/bazelbuild/bazel-skylib/releases/download/$VERSION/bazel-skylib-$VERSION.tar.gz"
+gsutil cp bazel-bin/distribution/bazel-skylib{,-gazelle-plugin}-$VERSION.tar.gz gs://bazel-mirror/github.com/bazelbuild/bazel-skylib/releases/download/$VERSION/
+gsutil setmeta -h "Cache-Control: public, max-age=31536000" gs://bazel-mirror/github.com/bazelbuild/bazel-skylib/releases/download/$VERSION/bazel-skylib{,-gazelle-plugin}-$VERSION.tar.gz
 ```
 
 6.  Obtain checksums for release notes:

--- a/docs/maintainers_guide.md
+++ b/docs/maintainers_guide.md
@@ -72,25 +72,33 @@ Name 1, Name 2, Name 3 (alphabetically from `git log`)
 
 --------------------------------------------------------------------------------
 
-2.  Bump `version` in version.bzl *and* MODULE.bazel to the new version.
-    TODO(#386): add a test to make sure the two versions are in sync.
+2.  Bump `version` in version.bzl, MODULE.bazel, *and* gazelle/MODULE.bazel to
+    the new version.
+    TODO(#386): add a test to make sure all the versions are in sync.
 3.  Ensure that the commits for steps 1 and 2 have been merged. All further
     steps must be performed on a single, known-good git commit.
-4.  `bazel build //distribution:bazel-skylib-$VERSION.tar.gz`
-5.  Copy the `bazel-skylib-$VERSION.tar.gz` tarball to the mirror (you'll need
-    Bazel developer gcloud credentials; assuming you are a Bazel developer, you
-    can obtain them via `gcloud init`):
+4.  `bazel build //distribution`
+5.  Copy the `bazel-skylib-$VERSION.tar.gz` and
+    `bazel-skylib-gazelle-plugin-$VERSION.tar.gz` tarballs to the mirror (you'll
+    need Bazel developer gcloud credentials; assuming you are a Bazel developer,
+    you can obtain them via `gcloud init`):
 
-```
+```bash
 gsutil cp bazel-bin/distribution/bazel-skylib-$VERSION.tar.gz gs://bazel-mirror/github.com/bazelbuild/bazel-skylib/releases/download/$VERSION/bazel-skylib-$VERSION.tar.gz
 gsutil setmeta -h "Cache-Control: public, max-age=31536000" "gs://bazel-mirror/github.com/bazelbuild/bazel-skylib/releases/download/$VERSION/bazel-skylib-$VERSION.tar.gz"
 ```
 
-6.  Run `sha256sum bazel-bin/distro/bazel-skylib-$VERSION.tar.gz`; you'll need
-    the checksum for the release notes.
+6.  Obtain checksums for release notes:
+
+```bash
+sha256sum bazel-bin/distro/bazel-skylib-$VERSION.tar.gz
+sha256sum bazel-bin/distro/bazel-skylib-gazelle-plugin-$VERSION.tar.gz
+````
+
 7.  Draft a new release with a new tag named $VERSION in github. Attach
-    `bazel-skylib-$VERSION.tar.gz` to the release. For the release notes, use
-    the CHANGELOG.md entry plus the following template:
+    `bazel-skylib-$VERSION.tar.gz` and
+    `bazel-skylib-gazelle-plugin-$VERSION.tar.gz` to the release. For the
+    release notes, use the CHANGELOG.md entry plus the following template:
 
 --------------------------------------------------------------------------------
 

--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-bzl_library   (
+bzl_library(
     name = "setup",
     srcs = ["setup.bzl"],
     visibility = ["//visibility:public"],

--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -1,18 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-# The files needed for distribution
-filegroup(
-    name = "distribution",
-    srcs = glob(
-        ["*"],
-        allow_empty = True,
-    ),
-    visibility = [
-        "//:__pkg__",
-    ],
-)
-
-bzl_library(
+bzl_library   (
     name = "setup",
     srcs = ["setup.bzl"],
     visibility = ["//visibility:public"],
@@ -31,4 +19,14 @@ bzl_library(
         "@bazel_tools//tools/build_defs/repo:http.bzl",
         "@bazel_tools//tools/build_defs/repo:utils.bzl",
     ],
+)
+
+# TODO(arostovtsev): exclude everything below from distro tarball
+filegroup(
+    name = "distribution",
+    srcs = glob(
+        ["*"],
+        allow_empty = True,
+    ),
+    visibility = ["//visibility:public"],
 )

--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -5,6 +5,7 @@ module(
     compatibility_level = 1,
 )
 
+# Keep in sync with @bazel_skylib//:MODULE.bazel and @bazel_skylib//:version.bzl
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "gazelle", version = "0.28.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_go", version = "0.35.0", repo_name = "io_bazel_rules_go")

--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -1,22 +1,20 @@
 module(
     name = "bazel_skylib_gazelle_plugin",
-    compatibility_level = 1,
     # Keep in sync with @bazel_skylib//:MODULE.bazel and @bazel_skylib//:version.bzl
     version = "1.3.0",
+    compatibility_level = 1,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
-bazel_dep(name = "gazelle", repo_name = "bazel_gazelle", version = "0.28.0")
-bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go", version = "0.35.0")
+bazel_dep(name = "gazelle", version = "0.28.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.35.0", repo_name = "io_bazel_rules_go")
 
 # `rules_go` will register a toolchain for us if the user doesn't do so
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
-
 go_deps.module(
     path = "github.com/bazelbuild/buildtools",
     sum = "h1:fmdo+fvvWlhldUcqkhAMpKndSxMN3vH5l7yow5cEaiQ=",
     version = "v0.0.0-20220531122519-a43aed7014c8",
 )
-
 use_repo(go_deps, "com_github_bazelbuild_buildtools")

--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "bazel_skylib_gazelle_plugin",
     compatibility_level = 1,
-    # If you change this, please also update @bazel_gazelle//:MODULE.bazel
+    # Keep in sync with @bazel_skylib//:MODULE.bazel and @bazel_skylib//:version.bzl
     version = "1.3.0",
 )
 

--- a/gazelle/bzl/BUILD
+++ b/gazelle/bzl/BUILD
@@ -52,6 +52,8 @@ gazelle(
     gazelle = ":gazelle-skylib",
 )
 
+# TODO(arostovtsev): exclude everything below from distro tarball
+
 # The files needed for distribution
 # A fake testdata directory is created so that
 # the build file has nothing missing, but we
@@ -62,10 +64,7 @@ filegroup(
         "BUILD",
         ":fake-testdata",
     ],
-    visibility = [
-        "//:__pkg__",
-        "//distribution:__pkg__",
-    ],
+    visibility = ["//visibility:public"],
 )
 
 genrule(

--- a/version.bzl
+++ b/version.bzl
@@ -13,4 +13,5 @@
 # limitations under the License.
 """The version of bazel-skylib."""
 
+# Keep in sync with MODULE.bazel and @bazel_skylib_gazelle_plugin//:MODULE.bazel
 version = "1.3.0"


### PR DESCRIPTION
After #400, the gazelle plugin has been cleanly separated out into its own bazel workspace, which will soon finally allow us to mark it stable. But this means:

* we need to change our bazelci config to explicitly build and test it, since `bazel build //...` no longer includes the plugin;
* we need to add proper distribution rules for it;
* we need to update release instructions, since now we will have two distribution tarballs