### PR TITLE
Update rules_go and gazelle deps to be compatible with --incompatible_disable_starlark_host_transitions

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -7,8 +7,8 @@ module(
 
 # Keep in sync with @bazel_skylib//:MODULE.bazel and @bazel_skylib//:version.bzl
 bazel_dep(name = "bazel_skylib", version = "1.4.0")
-bazel_dep(name = "gazelle", version = "0.28.0", repo_name = "bazel_gazelle")
-bazel_dep(name = "rules_go", version = "0.35.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.29.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.38.1", repo_name = "io_bazel_rules_go")
 
 # `rules_go` will register a toolchain for us if the user doesn't do so
 

--- a/gazelle/workspace.bzl
+++ b/gazelle/workspace.bzl
@@ -25,19 +25,19 @@ def bazel_skylib_gazelle_plugin_workspace():
     maybe(
         http_archive,
         name = "io_bazel_rules_go",
-        sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
+        sha256 = "dd926a88a564a9246713a9c00b35315f54cbd46b31a26d5d8fb264c07045f05d",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.38.1/rules_go-v0.38.1.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.38.1/rules_go-v0.38.1.zip",
         ],
     )
 
     maybe(
         http_archive,
         name = "bazel_gazelle",
-        sha256 = "448e37e0dbf61d6fa8f00aaa12d191745e14f07c31cabfa731f0c8e8a4f41b97",
+        sha256 = "ecba0f04f96b4960a5b250c8e8eeec42281035970aa8852dda73098274d14a1d",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
-            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.28.0/bazel-gazelle-v0.28.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.29.0/bazel-gazelle-v0.29.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.29.0/bazel-gazelle-v0.29.0.tar.gz",
         ],
     )


### PR DESCRIPTION
Partially addresses https://github.com/bazelbuild/bazel-skylib/issues/418