### PR TITLE
Avoid building build_test deps unnecessarily

### DIFF
--- a/rules/build_test.bzl
+++ b/rules/build_test.bzl
@@ -42,10 +42,10 @@ _empty_test = rule(
 )
 
 _GENRULE_ATTRS = [
-    "compatible_with", 
+    "compatible_with",
     "exec_compatible_with",
-    "restricted_to", 
-    "tags", 
+    "restricted_to",
+    "tags",
     "target_compatible_with",
 ]
 


### PR DESCRIPTION
I ran into an issue where I had a `build_test` that was only compatible with a particular platform. I had annotated the target with `target_compatible_with` but continued to get builds on the incompatible platform. This came down to my `bazel test //...` invocation picking up the `{name}_{idx}__deps` targets and building the dependency anyway. This change updates these targets to account for newer common attributes and tags them as manual so they're only built when the user facing test target is built.