### PR TITLE
Modify actions in order not to need `toolchain` param 

### DIFF
--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -1,7 +1,7 @@
-load("distribution.bzl", "remove_internal_only")
 load("@bazel_skylib//:version.bzl", "version")
-load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("@rules_pkg//:mappings.bzl", "pkg_files", "strip_prefix")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("distribution.bzl", "remove_internal_only")
 
 package(
     default_visibility = ["//visibility:private"],

--- a/docs/private/stardoc_with_diff_test.bzl
+++ b/docs/private/stardoc_with_diff_test.bzl
@@ -23,9 +23,9 @@ available from a third-party:
 https://github.com/aspect-build/bazel-lib/blob/main/docs/docs.md
 """
 
-load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
-load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 def stardoc_with_diff_test(
         name,

--- a/gazelle/workspace.bzl
+++ b/gazelle/workspace.bzl
@@ -14,9 +14,9 @@
 
 """Dependency registration helpers for repositories which need to load bazel-skylib's gazelle plugin."""
 
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 def bazel_skylib_gazelle_plugin_workspace():
     """Loads dependencies required to use skylib's gazelle plugin"""

--- a/rules/private/copy_file_private.bzl
+++ b/rules/private/copy_file_private.bzl
@@ -39,8 +39,7 @@ def copy_cmd(ctx, src, dst):
         is_executable = True,
     )
     ctx.actions.run(
-        inputs = [src],
-        tools = [bat],
+        inputs = [src, bat],
         outputs = [dst],
         executable = "cmd.exe",
         arguments = ["/C", bat.path.replace("/", "\\")],
@@ -52,7 +51,7 @@ def copy_cmd(ctx, src, dst):
 
 def copy_bash(ctx, src, dst):
     ctx.actions.run_shell(
-        tools = [src],
+        inputs = [src],
         outputs = [dst],
         command = "cp -f \"$1\" \"$2\"",
         arguments = [src.path, dst.path],

--- a/rules/run_binary.bzl
+++ b/rules/run_binary.bzl
@@ -22,7 +22,6 @@ load("//lib:dicts.bzl", "dicts")
 
 def _impl(ctx):
     tool_as_list = [ctx.attr.tool]
-    tool_inputs, tool_input_mfs = ctx.resolve_tools(tools = tool_as_list)
     args = [
         # Expand $(location) / $(locations) in args.
         #
@@ -45,13 +44,12 @@ def _impl(ctx):
     ctx.actions.run(
         outputs = ctx.outputs.outs,
         inputs = ctx.files.srcs,
-        tools = tool_inputs,
+        tools = [ctx.executable.tool],
         executable = ctx.executable.tool,
         arguments = args,
         mnemonic = "RunBinary",
         use_default_shell_env = False,
         env = dicts.add(ctx.configuration.default_shell_env, envs),
-        input_manifests = tool_input_mfs,
     )
     return DefaultInfo(
         files = depset(ctx.outputs.outs),

--- a/tests/build_test_tests.bzl
+++ b/tests/build_test_tests.bzl
@@ -14,8 +14,8 @@
 
 """Unit tests for build_test.bzl."""
 
-load("//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("//rules:build_test.bzl", "build_test")
 
 # buildifier: disable=unnamed-macro
 def build_test_test_suite():

--- a/tests/native_binary/BUILD
+++ b/tests/native_binary/BUILD
@@ -1,6 +1,6 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//rules:copy_file.bzl", "copy_file")
 load("//rules:native_binary.bzl", "native_binary", "native_test")
-load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 package(
     default_testonly = 1,

--- a/tests/run_binary/BUILD
+++ b/tests/run_binary/BUILD
@@ -1,7 +1,7 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//rules:diff_test.bzl", "diff_test")
 load("//rules:run_binary.bzl", "run_binary")
 load("//rules:write_file.bzl", "write_file")
-load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 package(
     default_testonly = 1,

--- a/tests/select_file/BUILD
+++ b/tests/select_file/BUILD
@@ -1,5 +1,5 @@
-load("//rules:select_file.bzl", "select_file")
 load("//rules:diff_test.bzl", "diff_test")
+load("//rules:select_file.bzl", "select_file")
 
 licenses(["notice"])
 

--- a/tests/types_tests.bzl
+++ b/tests/types_tests.bzl
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Unit tests for types.bzl."""
 
+load("//lib:new_sets.bzl", "sets")
 load("//lib:types.bzl", "types")
 load("//lib:unittest.bzl", "asserts", "unittest")
-load("//lib:new_sets.bzl", "sets")
 
 def _a_function():
     """A dummy function for testing."""


### PR DESCRIPTION
All actions which use tool or executable for which is not clear if it comes from a toolchain, must set a `toolchain` parameter ( migration of Automatic Exec Groups). 

As we discussed internally, I've modified actions so that it's recognised that tools are not from the toolchain. Hence, there will not be an error which states `Couldn't identify if tools are from implicit dependencies or a toolchain. Please set the toolchain parameter. If you're not using a toolchain, set it to 'None'.`. Hence, no need for the toolchain parameter.