### PR TITLE
Add error for empty bzl_library

### DIFF
--- a/bzl_library.bzl
+++ b/bzl_library.bzl
@@ -26,6 +26,9 @@ StarlarkLibraryInfo = provider(
 def _bzl_library_impl(ctx):
     deps_files = [x.files for x in ctx.attr.deps]
     all_files = depset(ctx.files.srcs, order = "postorder", transitive = deps_files)
+    if not ctx.files.srcs and not deps_files:
+        fail("bzl_library rule '%s' has no srcs or deps" % ctx.label)
+
     return [
         # All dependent files should be listed in both `files` and in `runfiles`;
         # this ensures that a `bzl_library` can be referenced as `data` from


### PR DESCRIPTION
This improves the error in the case your bzl_library does nothing. Otherwise you end up with something weirder later:

```
BUILD:35:12: in deps attribute of bzl_library rule LABEL: 'DEP' does not produce any bzl_library deps files (expected .bzl)
```

Ideally we could set `allow_empty = False` on `srcs` but currently it's valid to just have a bzl_library target that aggregates multiple other libraries in its deps.