### PR TITLE
Upgrade rules_go

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 # Keep in sync with @bazel_skylib//:MODULE.bazel and @bazel_skylib//:version.bzl
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "gazelle", version = "0.29.0", repo_name = "bazel_gazelle")
-bazel_dep(name = "rules_go", version = "0.38.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.41.0", repo_name = "io_bazel_rules_go")
 
 # `rules_go` will register a toolchain for us if the user doesn't do so
 

--- a/gazelle/setup.bzl
+++ b/gazelle/setup.bzl
@@ -17,7 +17,7 @@
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
-def bazel_skylib_gazelle_plugin_setup(go_version = "1.18.7", register_go_toolchains = True):
+def bazel_skylib_gazelle_plugin_setup(go_version = "1.20.5", register_go_toolchains = True):
     """Set up the dependencies needed by the Gazelle plugin.
 
     Args:

--- a/gazelle/workspace.bzl
+++ b/gazelle/workspace.bzl
@@ -25,10 +25,10 @@ def bazel_skylib_gazelle_plugin_workspace():
     maybe(
         http_archive,
         name = "io_bazel_rules_go",
-        sha256 = "dd926a88a564a9246713a9c00b35315f54cbd46b31a26d5d8fb264c07045f05d",
+        sha256 = "278b7ff5a826f3dc10f04feaf0b70d48b68748ccd512d7f98bf442077f043fe3",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.38.1/rules_go-v0.38.1.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.38.1/rules_go-v0.38.1.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.41.0/rules_go-v0.41.0.zip",
         ],
     )
 


### PR DESCRIPTION
This fixes building bazel-skylib at head with Bazel at head.

Fixes: https://github.com/bazelbuild/bazel-skylib/issues/459