### PR TITLE
versions: Don't fail on Bazel dev builds

### DIFF
--- a/docs/versions_doc.md
+++ b/docs/versions_doc.md
@@ -26,6 +26,9 @@ Parses a version string into a 3-tuple of ints
 
 int tuples can be compared directly using binary operators (&lt;, &gt;).
 
+For a development build of Bazel, this returns an unspecified version tuple
+that compares higher than any released version.
+
 
 **PARAMETERS**
 

--- a/lib/versions.bzl
+++ b/lib/versions.bzl
@@ -44,6 +44,9 @@ def _parse_bazel_version(bazel_version):
 
     int tuples can be compared directly using binary operators (<, >).
 
+    For a development build of Bazel, this returns an unspecified version tuple
+    that compares higher than any released version.
+
     Args:
       bazel_version: the Bazel version string
 
@@ -52,6 +55,8 @@ def _parse_bazel_version(bazel_version):
     """
 
     version = _extract_version_number(bazel_version)
+    if not version:
+        return (999999, 999999, 999999)
     return tuple([int(n) for n in version.split(".")])
 
 def _is_at_most(threshold, version):

--- a/tests/versions_tests.bzl
+++ b/tests/versions_tests.bzl
@@ -26,6 +26,9 @@ def _parse_test(ctx):
     asserts.equals(env, (0, 4, 0), versions.parse("0.4.0"))
     asserts.equals(env, (0, 4, 0), versions.parse("0.4.0rc"))
 
+    # Verify that this doesn't fail - it corresponds to a dev build of Bazel.
+    versions.parse("")
+
     return unittest.end(env)
 
 def _version_comparison_test(ctx):
@@ -36,11 +39,13 @@ def _version_comparison_test(ctx):
     asserts.true(env, versions.is_at_least("0.9.0", "0.10.0rc2"))
     asserts.true(env, versions.is_at_least("0.9.0", "0.9.0rc3"))
     asserts.true(env, versions.is_at_least("0.9.0", "1.2.3"))
+    asserts.true(env, versions.is_at_least("0.9.0", ""))
 
     asserts.false(env, versions.is_at_most("0.4.0 123abcd", "0.10.0rc1 abcd123"))
     asserts.true(env, versions.is_at_most("0.4.0", "0.3.0rc2"))
     asserts.true(env, versions.is_at_most("0.4.0", "0.4.0rc3"))
     asserts.true(env, versions.is_at_most("1.4.0", "0.4.0rc3"))
+    asserts.false(env, versions.is_at_most("1.4.0", ""))
 
     return unittest.end(env)
 


### PR DESCRIPTION
Dev builds of Bazel are assumed to be more recent than any released version.