### PR TITLE
Add `doc` param to `unittest.make`

### DIFF
--- a/docs/unittest_doc.md
+++ b/docs/unittest_doc.md
@@ -426,7 +426,7 @@ Registers the toolchains for unittest users.
 ## unittest.make
 
 <pre>
-unittest.make(<a href="#unittest.make-impl">impl</a>, <a href="#unittest.make-attrs">attrs</a>)
+unittest.make(<a href="#unittest.make-impl">impl</a>, <a href="#unittest.make-attrs">attrs</a>, <a href="#unittest.make-doc">doc</a>)
 </pre>
 
 Creates a unit test rule from its implementation function.
@@ -462,6 +462,7 @@ Recall that names of test rules must end in `_test`.
 | :------------- | :------------- | :------------- |
 | <a id="unittest.make-impl"></a>impl |  The implementation function of the unit test.   |  none |
 | <a id="unittest.make-attrs"></a>attrs |  An optional dictionary to supplement the attrs passed to the unit test's <code>rule()</code> constructor.   |  <code>{}</code> |
+| <a id="unittest.make-doc"></a>doc |  A description of the rule that can be extracted by documentation generating tools.   |  <code>""</code> |
 
 **RETURNS**
 

--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -148,7 +148,7 @@ def _impl_function_name(impl):
     impl_name = impl_name.partition("<function ")[-1]
     return impl_name.rpartition(">")[0]
 
-def _make(impl, attrs = {}):
+def _make(impl, attrs = {}, doc = ""):
     """Creates a unit test rule from its implementation function.
 
     Each unit test is defined in an implementation function that must then be
@@ -178,6 +178,7 @@ def _make(impl, attrs = {}):
       impl: The implementation function of the unit test.
       attrs: An optional dictionary to supplement the attrs passed to the
           unit test's `rule()` constructor.
+      doc: A description of the rule that can be extracted by documentation generating tools.
 
     Returns:
       A rule definition that should be stored in a global whose name ends in
@@ -188,6 +189,7 @@ def _make(impl, attrs = {}):
 
     return rule(
         impl,
+        doc = doc,
         attrs = attrs,
         _skylark_testable = True,
         test = True,


### PR DESCRIPTION
Same change as https://github.com/bazelbuild/bazel-skylib/pull/343 but now for `unittest`