### PR TITLE
Add option to include runfiles files in the `select_file` search

### DIFF
--- a/docs/select_file_doc.md
+++ b/docs/select_file_doc.md
@@ -11,7 +11,7 @@ Selects a single file from the outputs of a target by given relative path.
 ## select_file
 
 <pre>
-select_file(<a href="#select_file-name">name</a>, <a href="#select_file-srcs">srcs</a>, <a href="#select_file-subpath">subpath</a>)
+select_file(<a href="#select_file-name">name</a>, <a href="#select_file-include_runfiles">include_runfiles</a>, <a href="#select_file-srcs">srcs</a>, <a href="#select_file-subpath">subpath</a>)
 </pre>
 
 Selects a single file from the outputs of a target by given relative path
@@ -22,6 +22,7 @@ Selects a single file from the outputs of a target by given relative path
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="select_file-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="select_file-include_runfiles"></a>include_runfiles |  Whether to include the runfiles in the search   | Boolean | optional | <code>False</code> |
 | <a id="select_file-srcs"></a>srcs |  The target producing the file among other outputs   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="select_file-subpath"></a>subpath |  Relative path to the file   | String | required |  |
 

--- a/rules/select_file.bzl
+++ b/rules/select_file.bzl
@@ -24,7 +24,10 @@ def _impl(ctx):
 
     out = None
     canonical = ctx.attr.subpath.replace("\\", "/")
-    for file_ in ctx.attr.srcs.files.to_list():
+    files_ = ctx.attr.srcs.files.to_list()
+    if ctx.attr.include_runfiles:
+        files_ += ctx.attr.srcs.default_runfiles.files.to_list()
+    for file_ in files_:
         if file_.path.replace("\\", "/").endswith(canonical):
             out = file_
             break
@@ -48,6 +51,10 @@ select_file = rule(
         "subpath": attr.string(
             mandatory = True,
             doc = "Relative path to the file",
+        ),
+        "include_runfiles": attr.bool(
+            default=False,
+            doc = "Whether to include the runfiles in the search",
         ),
     },
 )

--- a/rules/select_file.bzl
+++ b/rules/select_file.bzl
@@ -53,7 +53,7 @@ select_file = rule(
             doc = "Relative path to the file",
         ),
         "include_runfiles": attr.bool(
-            default=False,
+            default = False,
             doc = "Whether to include the runfiles in the search",
         ),
     },

--- a/rules/select_file.bzl
+++ b/rules/select_file.bzl
@@ -25,7 +25,7 @@ def _impl(ctx):
     out = None
     canonical = ctx.attr.subpath.replace("\\", "/")
     files_ = ctx.attr.srcs.files.to_list()
-    if ctx.attr.include_runfiles:
+    if ctx.attr.include_runfiles and ctx.attr.srcs.default_runfiles:
         files_ += ctx.attr.srcs.default_runfiles.files.to_list()
     for file_ in files_:
         if file_.path.replace("\\", "/").endswith(canonical):


### PR DESCRIPTION
Adds `include_runfiles` boolean argument to the `select_file` rule.

If set to `True`, runfiles files of the target is also searched for the matching `subpath` file.

resolves #466