### PR TITLE
Improve getting actions from the target under test

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -78,7 +78,9 @@ sh_test(
     srcs = ["analysis_test_test.sh"],
     data = [
         ":unittest.bash",
+        "//lib:unittest",
         "//rules:analysis_test.bzl",
+        "//toolchains/unittest:test_deps",
         "@bazel_tools//tools/bash/runfiles",
     ],
     tags = ["local"],


### PR DESCRIPTION
Improve getting actions from the target under test:

1. Add an keyword "mnemonic" parameter to `analysistest.target_actions()` to filter actions by mnemonic.

2. Add `analysistest.target_action(env, mnemonic=None, output_ending_with=None)` to get a single action by mnemonic or by one of its outputs.