### PR TITLE
Add `env` and `env_inherit` to `native_binary` and `native_test`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,7 @@ register_toolchains(
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
+
 globals = use_extension("//:extension.bzl", "globals_extension")
 use_repo(globals, "bazel_skylib_globals")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,8 @@ register_toolchains(
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
+globals = use_extension("//:extension.bzl", "globals_extension")
+use_repo(globals, "bazel_skylib_globals")
 
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
 

--- a/MODULE.bazel-remove-override.patch
+++ b/MODULE.bazel-remove-override.patch
@@ -1,6 +1,6 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -22,8 +22,8 @@
+@@ -24,8 +24,8 @@
  # Needed for bazelci and for building distribution tarballs.
  # If using an unreleased version of bazel_skylib via git_override, apply
  # MODULE.bazel-remove-override.patch to remove the following lines:

--- a/MODULE.bazel-remove-override.patch
+++ b/MODULE.bazel-remove-override.patch
@@ -1,6 +1,6 @@
 --- MODULE.bazel
 +++ MODULE.bazel
-@@ -24,8 +24,8 @@
+@@ -25,8 +25,8 @@
  # Needed for bazelci and for building distribution tarballs.
  # If using an unreleased version of bazel_skylib via git_override, apply
  # MODULE.bazel-remove-override.patch to remove the following lines:

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -66,6 +66,7 @@ stardoc_with_diff_test(
     name = "native_binary",
     bzl_library_target = "//rules:native_binary",
     out_label = "//docs:native_binary_doc.md",
+    deps = ["//lib:versions.bzl", "@bazel_skylib_globals//:globals.bzl"],
 )
 
 stardoc_with_diff_test(

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -66,7 +66,10 @@ stardoc_with_diff_test(
     name = "native_binary",
     bzl_library_target = "//rules:native_binary",
     out_label = "//docs:native_binary_doc.md",
-    deps = ["//lib:versions.bzl", "@bazel_skylib_globals//:globals.bzl"],
+    deps = [
+        "//lib:versions.bzl",
+        "@bazel_skylib_globals//:globals.bzl",
+    ],
 )
 
 stardoc_with_diff_test(

--- a/docs/native_binary_doc.md
+++ b/docs/native_binary_doc.md
@@ -30,7 +30,7 @@ in genrule.tools for example. You can also augment the binary with runfiles.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="native_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="native_binary-data"></a>data |  data dependencies. See https://bazel.build/reference/be/common-definitions#typical.data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="native_binary-env"></a>env |  additional environment variables to set when the target is executed by <code>bazel</code>   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
+| <a id="native_binary-env"></a>env |  additional environment variables to set when the target is executed by <code>bazel</code>. Setting this requires bazel version 5.3.0 or later.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
 | <a id="native_binary-out"></a>out |  An output name for the copy of the binary   | String | required |  |
 | <a id="native_binary-src"></a>src |  path of the pre-built executable   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
@@ -57,8 +57,8 @@ the binary with runfiles.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="native_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="native_test-data"></a>data |  data dependencies. See https://bazel.build/reference/be/common-definitions#typical.data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
-| <a id="native_test-env"></a>env |  additional environment variables to set when the target is executed by <code>bazel</code>   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
-| <a id="native_test-env_inherit"></a>env_inherit |  additional environment variables to inherit from the external environment when the test is executed by <code>bazel test</code>   | List of strings | optional | <code>[]</code> |
+| <a id="native_test-env"></a>env |  additional environment variables to set when the target is executed by <code>bazel</code>. Setting this requires bazel version 5.3.0 or later.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
+| <a id="native_test-env_inherit"></a>env_inherit |  additional environment variables to inherit from the external environment when the test is executed by <code>bazel test</code>. Setting this requires bazel version 5.3.0 or later.   | List of strings | optional | <code>[]</code> |
 | <a id="native_test-out"></a>out |  An output name for the copy of the binary   | String | required |  |
 | <a id="native_test-src"></a>src |  path of the pre-built executable   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 

--- a/docs/native_binary_doc.md
+++ b/docs/native_binary_doc.md
@@ -13,7 +13,7 @@ don't depend on Bash and work with --shell_executable="".
 ## native_binary
 
 <pre>
-native_binary(<a href="#native_binary-name">name</a>, <a href="#native_binary-data">data</a>, <a href="#native_binary-out">out</a>, <a href="#native_binary-src">src</a>)
+native_binary(<a href="#native_binary-name">name</a>, <a href="#native_binary-data">data</a>, <a href="#native_binary-env">env</a>, <a href="#native_binary-out">out</a>, <a href="#native_binary-src">src</a>)
 </pre>
 
 
@@ -30,6 +30,7 @@ in genrule.tools for example. You can also augment the binary with runfiles.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="native_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="native_binary-data"></a>data |  data dependencies. See https://bazel.build/reference/be/common-definitions#typical.data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="native_binary-env"></a>env |  additional environment variables to set when the target is executed by <code>bazel</code>   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
 | <a id="native_binary-out"></a>out |  An output name for the copy of the binary   | String | required |  |
 | <a id="native_binary-src"></a>src |  path of the pre-built executable   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
@@ -39,7 +40,7 @@ in genrule.tools for example. You can also augment the binary with runfiles.
 ## native_test
 
 <pre>
-native_test(<a href="#native_test-name">name</a>, <a href="#native_test-data">data</a>, <a href="#native_test-out">out</a>, <a href="#native_test-src">src</a>)
+native_test(<a href="#native_test-name">name</a>, <a href="#native_test-data">data</a>, <a href="#native_test-env">env</a>, <a href="#native_test-env_inherit">env_inherit</a>, <a href="#native_test-out">out</a>, <a href="#native_test-src">src</a>)
 </pre>
 
 
@@ -56,6 +57,8 @@ the binary with runfiles.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="native_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="native_test-data"></a>data |  data dependencies. See https://bazel.build/reference/be/common-definitions#typical.data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | <code>[]</code> |
+| <a id="native_test-env"></a>env |  additional environment variables to set when the target is executed by <code>bazel</code>   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | <code>{}</code> |
+| <a id="native_test-env_inherit"></a>env_inherit |  additional environment variables to inherit from the external environment when the test is executed by <code>bazel test</code>   | List of strings | optional | <code>[]</code> |
 | <a id="native_test-out"></a>out |  An output name for the copy of the binary   | String | required |  |
 | <a id="native_test-src"></a>src |  path of the pre-built executable   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 

--- a/docs/private/stardoc_with_diff_test.bzl
+++ b/docs/private/stardoc_with_diff_test.bzl
@@ -30,7 +30,8 @@ load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 def stardoc_with_diff_test(
         name,
         bzl_library_target,
-        out_label):
+        out_label,
+        deps = None):
     """Creates a stardoc target coupled with a `diff_test` for a given `bzl_library`.
 
     This is helpful for minimizing boilerplate in repos with lots of stardoc targets.
@@ -47,7 +48,7 @@ def stardoc_with_diff_test(
         name = name,
         out = out_file.replace(".md", "-docgen.md"),
         input = bzl_library_target + ".bzl",
-        deps = [bzl_library_target],
+        deps = [bzl_library_target] + (deps or []),
     )
 
     # Ensure that the generated MD has been updated in the local source tree

--- a/docs/private/stardoc_with_diff_test.bzl
+++ b/docs/private/stardoc_with_diff_test.bzl
@@ -40,6 +40,7 @@ def stardoc_with_diff_test(
         name: the stardoc target name
         bzl_library_target: the label of the `bzl_library` target to generate documentation for
         out_label: the label of the output MD file
+        deps: additional files loaded by the bazel library, if any
     """
     out_file = out_label.replace("//", "").replace(":", "/")
 

--- a/extension.bzl
+++ b/extension.bzl
@@ -1,0 +1,6 @@
+load("@bazel_skylib//:workspace.bzl", "globals_repo")
+
+def _globals_extension_impl(module_ctx):
+    globals_repo()
+
+globals_extension = module_extension(_globals_extension_impl)

--- a/extension.bzl
+++ b/extension.bzl
@@ -1,6 +1,23 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module extension to load additional repositories"""
+
 load("@bazel_skylib//:workspace.bzl", "globals_repo")
 
-def _globals_extension_impl(module_ctx):
+def _globals_extension_impl(
+    module_ctx,  # @unused
+):
     globals_repo()
 
 globals_extension = module_extension(_globals_extension_impl)

--- a/extension.bzl
+++ b/extension.bzl
@@ -16,8 +16,7 @@
 load("@bazel_skylib//:workspace.bzl", "globals_repo")
 
 def _globals_extension_impl(
-    module_ctx,  # @unused
-):
+        module_ctx):  # @unused
     globals_repo()
 
 globals_extension = module_extension(_globals_extension_impl)

--- a/rules/native_binary.bzl
+++ b/rules/native_binary.bzl
@@ -28,7 +28,7 @@ def _impl_rule(ctx):
         for attr in ("env", "env_inherit"):
             if getattr(ctx.attr, attr, None):
                 fail("Attribute %s specified for %s is only supported with bazel >= 5.3.0" %
-                    (attr, ctx.label))
+                     (attr, ctx.label))
     out = ctx.actions.declare_file(ctx.attr.out)
     ctx.actions.symlink(
         target_file = ctx.executable.src,
@@ -79,7 +79,7 @@ _ATTRS = {
     "data": attr.label_list(
         allow_files = True,
         doc = "data dependencies. See" +
-            " https://bazel.build/reference/be/common-definitions#typical.data",
+              " https://bazel.build/reference/be/common-definitions#typical.data",
     ),
     # "out" is attr.string instead of attr.output, so that it is select()'able.
     "out": attr.string(mandatory = True, doc = "An output name for the copy of the binary"),
@@ -90,7 +90,8 @@ _ATTRS = {
     ),
 }
 
-_TEST_ATTRS = dict(_ATTRS,
+_TEST_ATTRS = dict(
+    _ATTRS,
     env_inherit = attr.string_list(
         doc = "additional environment variables to inherit from the external " +
               "environment when the test is executed by `bazel test`",

--- a/rules/native_binary.bzl
+++ b/rules/native_binary.bzl
@@ -20,7 +20,6 @@ do, but they run the wrapped binary directly, instead of through Bash, so they
 don't depend on Bash and work with --shell_executable="".
 """
 
-load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@bazel_skylib_globals//:globals.bzl", "globals")
 
 def _impl_rule(ctx):
@@ -57,12 +56,12 @@ def _impl_rule(ctx):
         ),
     ]
     if globals.RunEnvironmentInfo:
-        ret += [
+        ret.append(
             globals.RunEnvironmentInfo(
                 environment = ctx.attr.env,
                 inherited_environment = getattr(ctx.attr, "env_inherit", []),
             ),
-        ]
+        )
     return ret
 
 _ATTRS = {

--- a/rules/native_binary.bzl
+++ b/rules/native_binary.bzl
@@ -84,7 +84,7 @@ _ATTRS = {
     "out": attr.string(mandatory = True, doc = "An output name for the copy of the binary"),
     "env": attr.string_dict(
         doc = "additional environment variables to set when the target is executed by " +
-              "`bazel`",
+              "`bazel`. Setting this requires bazel version 5.3.0 or later.",
         default = {},
     ),
 }
@@ -93,7 +93,8 @@ _TEST_ATTRS = dict(
     _ATTRS,
     env_inherit = attr.string_list(
         doc = "additional environment variables to inherit from the external " +
-              "environment when the test is executed by `bazel test`",
+              "environment when the test is executed by `bazel test`. " +
+              "Setting this requires bazel version 5.3.0 or later.",
         default = [],
     ),
 )

--- a/rules/native_binary.bzl
+++ b/rules/native_binary.bzl
@@ -41,11 +41,17 @@ def _impl_rule(ctx):
             runfiles = runfiles.merge(d[DefaultInfo].default_runfiles)
         runfiles = runfiles.merge(ctx.attr.src[DefaultInfo].default_runfiles)
 
-    return DefaultInfo(
-        executable = out,
-        files = depset([out]),
-        runfiles = runfiles,
-    )
+    return [
+        DefaultInfo(
+            executable = out,
+            files = depset([out]),
+            runfiles = runfiles,
+        ),
+        RunEnvironmentInfo(
+            environment = ctx.attr.env,
+            inherited_environment = ctx.attr.env_inherit,
+        ),
+    ]
 
 _ATTRS = {
     "src": attr.label(
@@ -65,6 +71,8 @@ _ATTRS = {
     ),
     # "out" is attr.string instead of attr.output, so that it is select()'able.
     "out": attr.string(mandatory = True, doc = "An output name for the copy of the binary"),
+    "env": attr.string_dict(doc = "Environment to provide to the execution of the binary", default = {}),
+    "env_inherit": attr.string_list(doc = "Environment to preserve for the execution of the binary", default = []),
 }
 
 native_binary = rule(

--- a/tests/native_binary/BUILD
+++ b/tests/native_binary/BUILD
@@ -142,7 +142,6 @@ native_test(
         "TEST_ENV_VAR": "test_env_var_value",
     },
     env_inherit = [
-        "HOME",  # for POSIX
-        "HOMEPATH",  # for Windows
+        "HOME",  # only checked on POSIX
     ],
 )

--- a/tests/native_binary/BUILD
+++ b/tests/native_binary/BUILD
@@ -142,6 +142,7 @@ native_test(
         "TEST_ENV_VAR": "test_env_var_value",
     },
     env_inherit = [
-        "HOME",  # only checked on POSIX
+        "HOME",  # for POSIX
+        "APPDATA",  # for Windows
     ],
 )

--- a/tests/native_binary/BUILD
+++ b/tests/native_binary/BUILD
@@ -31,8 +31,8 @@ cc_binary(
 )
 
 cc_binary(
-    name="assertenv",
-    srcs=["assertenv.cc"],
+    name = "assertenv",
+    srcs = ["assertenv.cc"],
 )
 
 # A rule that copies "assertarg"'s output as an opaque executable, simulating a
@@ -60,13 +60,13 @@ copy_file(
 )
 
 copy_file(
-    name="copy_assertenv_exe",
-    src=":assertenv",
+    name = "copy_assertenv_exe",
+    src = ":assertenv",
     # On Windows we need the ".exe" extension.
     # On other platforms the extension doesn't matter.
     # Therefore we can use ".exe" on every platform.
-    out="assertenv_copy.exe",
-    is_executable=True,
+    out = "assertenv_copy.exe",
+    is_executable = True,
 )
 
 _ARGS = [
@@ -132,16 +132,16 @@ native_test(
 )
 
 native_test(
-    name="env_test",
-    src=":copy_assertenv_exe",
+    name = "env_test",
+    src = ":copy_assertenv_exe",
     # On Windows we need the ".exe" extension.
     # On other platforms the extension doesn't matter.
     # Therefore we can use ".exe" on every platform.
-    out="env_test.exe",
-    env={
+    out = "env_test.exe",
+    env = {
         "TEST_ENV_VAR": "test_env_var_value",
     },
-    env_inherit=[
+    env_inherit = [
         "HOME",  # for POSIX
         "HOMEPATH",  # for Windows
     ],

--- a/tests/native_binary/BUILD
+++ b/tests/native_binary/BUILD
@@ -30,6 +30,11 @@ cc_binary(
     deps = ["@bazel_tools//tools/cpp/runfiles"],
 )
 
+cc_binary(
+    name="assertenv",
+    srcs=["assertenv.cc"],
+)
+
 # A rule that copies "assertarg"'s output as an opaque executable, simulating a
 # binary that's not built from source and needs to be wrapped in native_binary.
 copy_file(
@@ -52,6 +57,16 @@ copy_file(
     # Therefore we can use ".exe" on every platform.
     out = "assertdata_copy.exe",
     is_executable = True,
+)
+
+copy_file(
+    name="copy_assertenv_exe",
+    src=":assertenv",
+    # On Windows we need the ".exe" extension.
+    # On other platforms the extension doesn't matter.
+    # Therefore we can use ".exe" on every platform.
+    out="assertenv_copy.exe",
+    is_executable=True,
 )
 
 _ARGS = [
@@ -114,4 +129,20 @@ native_test(
     # On other platforms the extension doesn't matter.
     # Therefore we can use ".exe" on every platform.
     out = "data_from_binary_test.exe",
+)
+
+native_test(
+    name="env_test",
+    src=":copy_assertenv_exe",
+    # On Windows we need the ".exe" extension.
+    # On other platforms the extension doesn't matter.
+    # Therefore we can use ".exe" on every platform.
+    out="env_test.exe",
+    env={
+        "TEST_ENV_VAR": "test_env_var_value",
+    },
+    env_inherit=[
+        "HOME",  # for POSIX
+        "HOMEPATH",  # for Windows
+    ],
 )

--- a/tests/native_binary/assertenv.cc
+++ b/tests/native_binary/assertenv.cc
@@ -1,6 +1,16 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef _WIN32
+bool is_home_env(const char *env) {
+  return _strnicmp(env, "HOMEPATH=", strlen("HOMEPATH=")) == 0;
+}
+#else
+bool is_home_env(const char *env) {
+  return strncmp(env, "HOME=", strlen("HOME=")) == 0;
+}
+#endif
+
 int main(int argc, char **argv, char **envp) {
   bool test_env_found = false;
   bool home_found = false;
@@ -8,8 +18,7 @@ int main(int argc, char **argv, char **envp) {
     if (strcmp(*env, "TEST_ENV_VAR=test_env_var_value") == 0) {
       test_env_found = true;
     }
-    if (strncmp(*env, "HOME=", strlen("HOME=")) == 0 ||
-        strncasecmp(*env, "HOMEPATH=", strlen("HOMEPATH=")) == 0) {
+    if (is_home_env(*env)) {
       home_found = true;
     }
   }

--- a/tests/native_binary/assertenv.cc
+++ b/tests/native_binary/assertenv.cc
@@ -2,30 +2,30 @@
 #include <string.h>
 
 #ifdef _WIN32
-bool check_home(const char *env) { return true; }
+#define OS_VAR "APPDATA"
+#define strncasecmp _strnicmp
 #else
-bool check_home(const char *env) {
-  return strncmp(env, "HOME=", strlen("HOME=")) == 0;
-}
+#define OS_VAR "HOME"
 #endif
 
 int main(int argc, char **argv, char **envp) {
   bool test_env_found = false;
-  bool home_found = false;
+  bool inherited_var_found = false;
   for (char **env = envp; *env != NULL; ++env) {
+    printf("%s\n", *env);
     if (strcmp(*env, "TEST_ENV_VAR=test_env_var_value") == 0) {
       test_env_found = true;
     }
-    if (check_home(*env)) {
-      home_found = true;
+	if (strncasecmp(*env, OS_VAR "=", strlen(OS_VAR "=")) == 0) {
+      inherited_var_found = true;
     }
   }
   if (!test_env_found) {
     fprintf(stderr,
             "expected TEST_ENV_VAR=test_env_var_value in environment\n");
   }
-  if (!home_found) {
-    fprintf(stderr, "expected HOME in environment\n");
+  if (!inherited_var_found) {
+    fprintf(stderr, "expected " OS_VAR " in environment\n");
   }
-  return test_env_found && home_found ? 0 : 1;
+  return test_env_found && inherited_var_found ? 0 : 1;
 }

--- a/tests/native_binary/assertenv.cc
+++ b/tests/native_binary/assertenv.cc
@@ -2,11 +2,9 @@
 #include <string.h>
 
 #ifdef _WIN32
-bool is_home_env(const char *env) {
-  return _strnicmp(env, "HOMEPATH=", strlen("HOMEPATH=")) == 0;
-}
+bool check_home(const char *env) { return true; }
 #else
-bool is_home_env(const char *env) {
+bool check_home(const char *env) {
   return strncmp(env, "HOME=", strlen("HOME=")) == 0;
 }
 #endif
@@ -18,7 +16,7 @@ int main(int argc, char **argv, char **envp) {
     if (strcmp(*env, "TEST_ENV_VAR=test_env_var_value") == 0) {
       test_env_found = true;
     }
-    if (is_home_env(*env)) {
+    if (check_home(*env)) {
       home_found = true;
     }
   }
@@ -27,7 +25,7 @@ int main(int argc, char **argv, char **envp) {
             "expected TEST_ENV_VAR=test_env_var_value in environment\n");
   }
   if (!home_found) {
-    fprintf(stderr, "expected HOME or HOMEPATH in environment\n");
+    fprintf(stderr, "expected HOME in environment\n");
   }
   return test_env_found && home_found ? 0 : 1;
 }

--- a/tests/native_binary/assertenv.cc
+++ b/tests/native_binary/assertenv.cc
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv, char **envp) {
+  bool test_env_found = false;
+  bool home_found = false;
+  for (char **env = envp; *env != NULL; ++env) {
+    if (strcmp(*env, "TEST_ENV_VAR=test_env_var_value") == 0) {
+      test_env_found = true;
+    }
+    if (strncmp(*env, "HOME=", strlen("HOME=")) == 0 ||
+        strncasecmp(*env, "HOMEPATH=", strlen("HOMEPATH=")) == 0) {
+      home_found = true;
+    }
+  }
+  if (!test_env_found) {
+    fprintf(stderr,
+            "expected TEST_ENV_VAR=test_env_var_value in environment\n");
+  }
+  if (!home_found) {
+    fprintf(stderr, "expected HOME or HOMEPATH in environment\n");
+  }
+  return test_env_found && home_found ? 0 : 1;
+}

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -22,13 +22,16 @@ def _globals_repo_impl(repository_ctx):
         "RunEnvironmentInfo": "5.3.0",
     }
     globals = {
-        k: k if versions.is_at_least(v, versions.get()) else "None" for k, v in globals.items()
+        k: k if versions.is_at_least(v, versions.get()) else "None"
+        for k, v in globals.items()
     }
 
-    repository_ctx.file("globals.bzl",
+    repository_ctx.file(
+        "globals.bzl",
         "globals = struct(\n%s\n)\n" % "\n".join(
-            ["    %s = %s" % item for item in globals.items()]
-        ))
+            ["    %s = %s" % item for item in globals.items()],
+        ),
+    )
     repository_ctx.file("BUILD.bazel", "exports_files(['globals.bzl'])\n")
 
 _globals_repo = repository_rule(


### PR DESCRIPTION
This relies on the `RunEnvironmentInfo` that was introduced in bazel 5.3.0. To keep the library compatible with previous versions, a new `bazel_skylib_globals` is added that will provide a `None` definition of `RunEnvironmentInfo`  if still unavailable.

This is inspired by [bazel_features](https://github.com/bazel-contrib/bazel_features): while using that directly would be easy with bzlmod integration, for the legacy workspace-based integration would suffer, as `bazel_skylib_workspace` would only be able to bring `bazel_features` in the workspace, but then one would have to call `bazel_features_deps()` as well after `load`ing it.

If updating the legacy worksapce integration instructions with the above addition is deemed ok, one could bring that additionally dependency in. Otherwise I just added the necessary code to inspect the version (with the painful external repo workaround) directly in here.

Closes https://github.com/bazelbuild/bazel-skylib/issues/409