### PR TITLE
Add licenses spec to new BUILD file

### DIFF
--- a/tests/common_settings/BUILD
+++ b/tests/common_settings/BUILD
@@ -1,5 +1,9 @@
 load("//rules:common_settings.bzl", "int_flag", "string_flag")
 
+licenses(["notice"])
+
+package(default_testonly = 1)
+
 int_flag(
     name = "my_int_flag",
     build_setting_default = 42,


### PR DESCRIPTION
Internal linter complains about lack of license info.