### PR TITLE
Adding `expansion.bzl` for Fully Expanding Environment Variables

### DIFF
--- a/lib/expansion.bzl
+++ b/lib/expansion.bzl
@@ -1,0 +1,338 @@
+
+"""Skylib module containing functions that aid in environment variable expansion."""
+
+def _valid_char_for_env_var_name(char):
+    return char.isalnum() or char == "_"
+
+def _key_to_be_expanded(str_with_key, key, start_of_key_index):
+    # Check that the string at index is prefixed with an odd number of `$`.
+    # Odd number means that the last `$` is not escaped.
+    dollar_sign_count = 0
+    for index in range(start_of_key_index, -1, -1):
+        if str_with_key[index] != "$":
+          break
+        dollar_sign_count += 1
+
+    # Check that the key is correctly matched.
+    # Specifically, check the key isn't matching to another key (substring).
+    key_mismatch = False
+    if key[-1] not in (")", "}"):
+        end_of_key_index = start_of_key_index + len(key)
+        key_mismatch = (
+            (end_of_key_index < len(str_with_key)) and
+            _valid_char_for_env_var_name(str_with_key[end_of_key_index])
+        )
+
+    return (not key_mismatch) and (dollar_sign_count % 2) == 1
+
+def _expand_key_in_str(key, val, unexpanded_str):
+    key_len = len(key)
+    val_len = len(val)
+    searched_index = 0
+    expanded_str = unexpanded_str
+    # Max iterations at the length of the str; will likely break out earlier.
+    for _ in range(len(expanded_str)):
+        used_key_index = expanded_str.find(key, searched_index)
+        if used_key_index < 0:
+            break
+        if _key_to_be_expanded(expanded_str, key, used_key_index):
+            # Only replace this one instance that we have verified (count = 1).
+            # Avoid extra string splicing, if possible.
+            if searched_index == 0:
+                expanded_str = expanded_str.replace(key, val, 1)
+            else:
+                expanded_str = (
+                    expanded_str[0:searched_index-1] +
+                    expanded_str[searched_index:].replace(key, val, 1)
+                )
+            searched_index += val_len
+        else:
+            searched_index += key_len
+    return expanded_str
+
+def _expand_all_keys_in_str_from_dict(replacement_dict, unexpanded_str):
+    # Manually expand variables based on the var dict.
+    # Do not use `ctx.expand_make_variables()` as it will error out if any variable expands to
+    # `$(location <name>)` (or similar) instead of leaving it untouched.
+    expanded_val = unexpanded_str
+    for avail_key, corresponding_val in replacement_dict.items():
+        if expanded_val.find(avail_key) < 0:
+            continue
+        considered_key_formats = ("${}", "${{{}}}", "$({})")
+        formatted_keys = [key_format.format(avail_key) for key_format in considered_key_formats]
+        # Skip self-references (e.g. {"VAR": "$(VAR)"})
+        # This may happen (and is ok) for the `env` attribute, where keys can be reused to be
+        # expanded by the resolved dict.
+        if corresponding_val in formatted_keys:
+            continue
+        # Expand each format style of this key, if it exists.
+        for formatted_key in formatted_keys:
+            expanded_val = _expand_key_in_str(formatted_key, corresponding_val, expanded_val)
+    return expanded_val
+
+def _expand_tc_all_keys_in_str(resolved_replacement_dict, env_replacement_dict, unexpanded_str):
+    if unexpanded_str.find("$") < 0:
+        return unexpanded_str
+
+    expanded_val = unexpanded_str
+    prev_val = expanded_val
+    # Max iterations at the length of the str; will likely break out earlier.
+    for _ in range(len(expanded_val)):
+        # Expand values first from the `env` attribute, then by the toolchain resolved values.
+        expanded_val = _expand_all_keys_in_str_from_dict(env_replacement_dict, expanded_val)
+        expanded_val = _expand_all_keys_in_str_from_dict(resolved_replacement_dict, expanded_val)
+
+        # Break out early if nothing changed in this iteration.
+        if prev_val == expanded_val:
+            break
+        prev_val = expanded_val
+
+    return expanded_val
+
+def _expand_tc_and_loc_all_keys_in_str(
+        expand_location,
+        resolved_replacement_dict,
+        env_replacement_dict,
+        unexpanded_str):
+    if unexpanded_str.find("$") < 0:
+        return unexpanded_str
+
+    expanded_val = unexpanded_str
+    prev_val = expanded_val
+    # Max iterations at the length of the str; will likely break out earlier.
+    for _ in range(len(expanded_val)):
+        # First let's try the safe `location` (et al) expansion logic.
+        # `$VAR`, `$(VAR)`, and `${VAR}` will be left untouched.
+        expanded_val = expand_location(expanded_val)
+
+        # Break early if nothing left to expand.
+        if expanded_val.find("$") < 0:
+            break
+
+        # Expand values first from the `env` attribute, then by the toolchain resolved values.
+        expanded_val = _expand_all_keys_in_str_from_dict(env_replacement_dict, expanded_val)
+        expanded_val = _expand_all_keys_in_str_from_dict(resolved_replacement_dict, expanded_val)
+
+        # Break out early if nothing changed in this iteration.
+        if prev_val == expanded_val:
+            break
+        prev_val = expanded_val
+
+    return expanded_val
+
+def _expand_with_manual_dict(resolution_dict, source_env_dict):
+    """
+    Recursively expands all values in `source_env_dict` using the given lookup data.
+
+    All keys of `source_env_dict` are returned in the resultant dict with values expanded by
+    lookups via `resolution_dict` dict.
+    This function does not modify any of the given parameters.
+
+    Args:
+        resolution_dict:    (Required) A dictionary with resolved key/value pairs to be used for
+                            lookup when resolving values. This may come from toolchains (via
+                            `ctx.var`) or other sources.
+        source_env_dict:    (Required) The source for all desired expansions. All key/value pairs
+                            will appear within the returned dictionary, with all values fully
+                            expanded by lookups in `resolution_dict`.
+
+    Returns:
+      A new dict with all key/values from `source_env_dict`, where all values have been recursively
+      expanded.
+    """
+    expanded_envs = {}
+    for env_key, unexpanded_val in source_env_dict.items():
+        expanded_envs[env_key] = (
+            _expand_tc_all_keys_in_str(
+                resolution_dict,
+                source_env_dict,
+                unexpanded_val
+            )
+        )
+    return expanded_envs
+
+def _expand_with_manual_dict_and_location(expand_location, resolution_dict, source_env_dict):
+    """
+    Recursively expands all values in `source_env_dict` using the given logic / lookup data.
+
+    All keys of `source_env_dict` are returned in the resultant dict with values expanded by
+    location expansion logic via `expand_location` and by lookups via `resolution_dict` dict.
+    This function does not modify any of the given parameters.
+
+    Args:
+        expand_location:    (Required) A function that takes in a string and properly replaces
+                            `$(location ...)` (and similar) with the corresponding values. This
+                            likely should correspond to `ctx.expand_location()`.
+        resolution_dict:    (Required) A dictionary with resolved key/value pairs to be used for
+                            lookup when resolving values. This may come from toolchains (via
+                            `ctx.var`) or other sources.
+        source_env_dict:    (Required) The source for all desired expansions. All key/value pairs
+                            will appear within the returned dictionary, with all values fully
+                            expanded by the logic expansion logic of `expand_location` and by
+                            lookup in `resolution_dict`.
+
+    Returns:
+      A new dict with all key/values from `source_env_dict`, where all values have been recursively
+      expanded.
+    """
+    expanded_envs = {}
+    for env_key, unexpanded_val in source_env_dict.items():
+        expanded_envs[env_key] = (
+            _expand_tc_and_loc_all_keys_in_str(
+                expand_location,
+                resolution_dict,
+                source_env_dict,
+                unexpanded_val)
+        )
+    return expanded_envs
+
+def _expand_with_toolchains(ctx, source_env_dict, additional_lookup_dict = None):
+    """
+    Recursively expands all values in `source_env_dict` using the given lookup data.
+
+    All keys of `source_env_dict` are returned in the resultant dict with values expanded by
+    lookups via `ctx.var` dict (unioned with optional `additional_lookup_dict` parameter).
+    This function does not modify any of the given parameters.
+
+    Args:
+        ctx:    (Required) The bazel context object. This is used to access the `ctx.var` member
+                for use as the "resolution dict". This makes use of providers from toolchains for
+                environment variable expansion.
+        source_env_dict:    (Required) The source for all desired expansions. All key/value pairs
+                            will appear within the returned dictionary, with all values fully
+                            expanded by lookups in `resolution_dict`.
+        additional_lookup_dict: (Optional) Additional dict to be used with `ctx.var` (union) for
+                                variable expansion.
+
+    Returns:
+      A new dict with all key/values from `source_env_dict`, where all values have been recursively
+      expanded.
+    """
+    resolution_dict = ctx.var
+    if additional_lookup_dict:
+        resolution_dict = resolution_dict | additional_lookup_dict
+    return _expand_with_manual_dict(resolution_dict, source_env_dict)
+
+def _expand_with_toolchains_and_location(
+        ctx,
+        deps,
+        source_env_dict,
+        additional_lookup_dict = None):
+    """
+    Recursively expands all values in `source_env_dict` using the `ctx` logic / lookup data.
+
+    All keys of `source_env_dict` are returned in the resultant dict with values expanded by
+    location expansion logic via `ctx.expand_location` and by lookups via `ctx.var` dict (unioned
+    with optional `additional_lookup_dict` parameter).
+    This function does not modify any of the given parameters.
+
+    Args:
+        ctx:    (Required) The bazel context object. This is used to access the `ctx.var` member
+                for use as the "resolution dict". This makes use of providers from toolchains for
+                environment variable expansion. This object is also used for the
+                `ctx.expand_location` method to handle `$(location ...)` (and similar) expansion
+                logic.
+        deps:   (Required) The set of targets used with `ctx.expand_location` for expanding
+                `$(location ...)` (and similar) expressions.
+        source_env_dict:    (Required) The source for all desired expansions. All key/value pairs
+                            will appear within the returned dictionary, with all values fully
+                            expanded by the logic expansion logic of `expand_location` and by
+                            lookup in `resolution_dict`.
+        additional_lookup_dict: (Optional) Additional dict to be used with `ctx.var` (union) for
+                                variable expansion.
+
+    Returns:
+      A new dict with all key/values from `source_env_dict`, where all values have been recursively
+      expanded.
+    """
+    def _simpler_expand_location(input_str):
+        return ctx.expand_location(input_str, deps)
+    resolution_dict = ctx.var
+    if additional_lookup_dict:
+        resolution_dict = resolution_dict | additional_lookup_dict
+    return _expand_with_manual_dict_and_location(
+        _simpler_expand_location,
+        resolution_dict,
+        source_env_dict
+    )
+
+def _expand_with_toolchains_attr(ctx, env_attr_name = "env", additional_lookup_dict = None):
+    """
+    Recursively expands all values in "env" attr dict using the `ctx` lookup data.
+
+    All keys of `env` attribute are returned in the resultant dict with values expanded by
+    lookups via `ctx.var` dict (unioned with optional `additional_lookup_dict` parameter).
+    The attribute used can be changed (instead of `env`) via the optional `env_attr_name` paramter.
+    This function does not modify any of the given parameters.
+
+    Args:
+        ctx:    (Required) The bazel context object. This is used to access the `ctx.var` member
+                for use as the "resolution dict". This makes use of providers from toolchains for
+                environment variable expansion. This object is also used to retrieve various
+                necessary attributes via `ctx.attr.<attr_name>`.
+        env_attr_name:  (Optional) The name of the attribute that is used as the source for all
+                        desired expansions. All key/value pairs will appear within the returned
+                        dictionary, with all values fully expanded by lookups in `resolution_dict`.
+                        Default value is "env".
+        additional_lookup_dict: (Optional) Additional dict to be used with `ctx.var` (union) for
+                                variable expansion.
+
+    Returns:
+      A new dict with all key/values from source attribute (default "env" attribute), where all
+      values have been recursively expanded.
+    """
+    return _expand_with_toolchains(
+        ctx,
+        getattr(ctx.attr, env_attr_name),
+        additional_lookup_dict = additional_lookup_dict
+    )
+
+def _expand_with_toolchains_and_location_attr(
+        ctx,
+        deps_attr_name = "deps",
+        env_attr_name = "env",
+        additional_lookup_dict = None):
+    """
+    Recursively expands all values in "env" attr dict using the `ctx` logic / lookup data.
+
+    All keys of `env` attribute are returned in the resultant dict with values expanded by
+    location expansion logic via `ctx.expand_location` and by lookups via `ctx.var` dict (unioned
+    with optional `additional_lookup_dict` parameter).
+    This function does not modify any of the given parameters.
+
+    Args:
+        ctx:    (Required) The bazel context object. This is used to access the `ctx.var` member
+                for use as the "resolution dict". This makes use of providers from toolchains for
+                environment variable expansion. This object is also used for the
+                `ctx.expand_location` method to handle `$(location ...)` (and similar) expansion
+                logic. This object is also used to retrieve various necessary attributes via
+                `ctx.attr.<attr_name>`. Default value is "deps".
+        deps_attr_name: (Optional) The name of the attribute which contains the set of targets used
+                        with `ctx.expand_location` for expanding `$(location ...)` (and similar)
+                        expressions.
+        env_attr_name:  (Optional) The name of the attribute that is used as the source for all
+                        desired expansions. All key/value pairs will appear within the returned
+                        dictionary, with all values fully expanded by lookups in `resolution_dict`.
+                        Default value is "env".
+        additional_lookup_dict: (Optional) Additional dict to be used with `ctx.var` (union) for
+                                variable expansion.
+
+    Returns:
+      A new dict with all key/values from source attribute (default "env" attribute), where all
+      values have been recursively expanded.
+    """
+    return _expand_with_toolchains_and_location(
+        ctx,
+        getattr(ctx.attr, deps_attr_name),
+        getattr(ctx.attr, env_attr_name),
+        additional_lookup_dict = additional_lookup_dict
+    )
+
+expansion = struct(
+    expand_with_manual_dict = _expand_with_manual_dict,
+    expand_with_manual_dict_and_location = _expand_with_manual_dict_and_location,
+    expand_with_toolchains = _expand_with_toolchains,
+    expand_with_toolchains_attr = _expand_with_toolchains_attr,
+    expand_with_toolchains_and_location = _expand_with_toolchains_and_location,
+    expand_with_toolchains_and_location_attr = _expand_with_toolchains_and_location_attr,
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -3,6 +3,7 @@ load(":build_test_tests.bzl", "build_test_test_suite")
 load(":collections_tests.bzl", "collections_test_suite")
 load(":common_settings_tests.bzl", "common_settings_test_suite")
 load(":dicts_tests.bzl", "dicts_test_suite")
+load(":expansion_tests.bzl", "expansion_test_suite")
 load(":new_sets_tests.bzl", "new_sets_test_suite")
 load(":partial_tests.bzl", "partial_test_suite")
 load(":paths_tests.bzl", "paths_test_suite")
@@ -28,6 +29,8 @@ collections_test_suite()
 common_settings_test_suite()
 
 dicts_test_suite()
+
+expansion_test_suite()
 
 new_sets_test_suite()
 

--- a/tests/expansion_tests.bzl
+++ b/tests/expansion_tests.bzl
@@ -1,0 +1,697 @@
+
+"""Unit tests for expansion.bzl."""
+
+load("//lib:expansion.bzl", "expansion")
+load("//lib:unittest.bzl", "asserts", "unittest")
+
+# String constants
+
+_TEST_DEP_TARGET_NAME = "expansion_tests__dummy"
+
+_MOCK_LOCATION_PATH_OF_DUMMY = "location/path/of/dummy"
+_MOCK_EXECPATH_PATH_OF_DUMMY = "execpath/path/of/dummy"
+_MOCK_ROOTPATH_PATH_OF_DUMMY = "rootpath/path/of/dummy"
+_MOCK_RLOCATIONPATH_PATH_OF_DUMMY = "rlocationpath/path/of/dummy"
+
+_GENRULE_LOCATION_PATH_OF_DUMMY = "bazel-out/k8-fastbuild/bin/tests/dummy.txt"
+_GENRULE_EXECPATH_PATH_OF_DUMMY = "bazel-out/k8-fastbuild/bin/tests/dummy.txt"
+_GENRULE_ROOTPATH_PATH_OF_DUMMY = "tests/dummy.txt"
+_GENRULE_RLOCATIONPATH_PATH_OF_DUMMY = "_main/tests/dummy.txt"
+
+# Test input dicts
+
+_ENV_DICT = {
+    "SIMPLE_VAL": "hello_world",
+    "ESCAPED_SIMPLE_VAL": "$$SIMPLE_VAL",
+    "LOCATION_VAL": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "EXECPATH_VAL": "$(execpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "ROOTPATH_VAL": "$(rootpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "RLOCATIONPATH_VAL": "$(rlocationpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "TOOLCHAIN_ENV_VAR_RAW": "$TOOLCHAIN_ENV_VAR",
+    "TOOLCHAIN_ENV_VAR_PAREN": "$(TOOLCHAIN_ENV_VAR)",
+    "TOOLCHAIN_ENV_VAR_CURLY": "${TOOLCHAIN_ENV_VAR}",
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW": "$TOOLCHAIN_TO_LOCATION_ENV_VAR",
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_PAREN": "$(TOOLCHAIN_TO_LOCATION_ENV_VAR)",
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_CURLY": "${TOOLCHAIN_TO_LOCATION_ENV_VAR}",
+    "INDIRECT_SIMPLE_VAL_RAW": "$SIMPLE_VAL",
+    "INDIRECT_SIMPLE_VAL_PAREN": "$(SIMPLE_VAL)",
+    "INDIRECT_SIMPLE_VAL_CURLY": "${SIMPLE_VAL}",
+    "INDIRECT_ESCAPED_SIMPLE_VAL_RAW": "$ESCAPED_SIMPLE_VAL",
+    "INDIRECT_ESCAPED_SIMPLE_VAL_PAREN": "$(ESCAPED_SIMPLE_VAL)",
+    "INDIRECT_ESCAPED_SIMPLE_VAL_CURLY": "${ESCAPED_SIMPLE_VAL}",
+    "INDIRECT_LOCATION_VAL_RAW": "$LOCATION_VAL",
+    "INDIRECT_LOCATION_VAL_PAREN": "$(LOCATION_VAL)",
+    "INDIRECT_LOCATION_VAL_CURLY": "${LOCATION_VAL}",
+    "INDIRECT_EXECPATH_VAL_RAW": "$EXECPATH_VAL",
+    "INDIRECT_EXECPATH_VAL_PAREN": "$(EXECPATH_VAL)",
+    "INDIRECT_EXECPATH_VAL_CURLY": "${EXECPATH_VAL}",
+    "INDIRECT_ROOTPATH_VAL_RAW": "$ROOTPATH_VAL",
+    "INDIRECT_ROOTPATH_VAL_PAREN": "$(ROOTPATH_VAL)",
+    "INDIRECT_ROOTPATH_VAL_CURLY": "${ROOTPATH_VAL}",
+    "INDIRECT_RLOCATIONPATH_VAL_RAW": "$RLOCATIONPATH_VAL",
+    "INDIRECT_RLOCATIONPATH_VAL_PAREN": "$(RLOCATIONPATH_VAL)",
+    "INDIRECT_RLOCATIONPATH_VAL_CURLY": "${RLOCATIONPATH_VAL}",
+    "INDIRECT_TOOLCHAIN_ENV_VAR_RAW": "$TOOLCHAIN_ENV_VAR_RAW",
+    "INDIRECT_TOOLCHAIN_ENV_VAR_PAREN": "$(TOOLCHAIN_ENV_VAR_RAW)",
+    "INDIRECT_TOOLCHAIN_ENV_VAR_CURLY": "${TOOLCHAIN_ENV_VAR_RAW}",
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW": "$TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW",
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_PAREN": "$(TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW)",
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_CURLY": "${TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW}",
+    "MULTI_INDIRECT_RAW": (
+        "$INDIRECT_SIMPLE_VAL_RAW-$INDIRECT_ESCAPED_SIMPLE_VAL_RAW-" +
+        "$INDIRECT_LOCATION_VAL_RAW-$INDIRECT_RLOCATIONPATH_VAL_RAW-" +
+        "$INDIRECT_TOOLCHAIN_ENV_VAR_RAW-$INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW"
+    ),
+    "MULTI_INDIRECT_PAREN": (
+        "$(INDIRECT_SIMPLE_VAL_RAW)-$(INDIRECT_ESCAPED_SIMPLE_VAL_RAW)-" +
+        "$(INDIRECT_LOCATION_VAL_RAW)-$(INDIRECT_RLOCATIONPATH_VAL_RAW)-" +
+        "$(INDIRECT_TOOLCHAIN_ENV_VAR_RAW)-$(INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW)"
+    ),
+    "MULTI_INDIRECT_CURLY": (
+        "${INDIRECT_SIMPLE_VAL_RAW}-${INDIRECT_ESCAPED_SIMPLE_VAL_RAW}-" +
+        "${INDIRECT_LOCATION_VAL_RAW}-${INDIRECT_RLOCATIONPATH_VAL_RAW}-" +
+        "${INDIRECT_TOOLCHAIN_ENV_VAR_RAW}-${INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW}"
+    ),
+    "UNRECOGNIZED_VAR": "$NOPE",
+    "UNRECOGNIZED_FUNC": "$(nope :" + _TEST_DEP_TARGET_NAME + ")",
+}
+
+_TOOLCHAIN_DICT = {
+    "TOOLCHAIN_ENV_VAR": "flag_value",
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+}
+
+# Test expected output dicts
+
+_EXPECTED_RESOLVED_DICT_NO_LOCATION = {
+    "SIMPLE_VAL": "hello_world",
+    "ESCAPED_SIMPLE_VAL": "$$SIMPLE_VAL",
+    "LOCATION_VAL": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "EXECPATH_VAL": "$(execpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "ROOTPATH_VAL": "$(rootpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "RLOCATIONPATH_VAL": "$(rlocationpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "TOOLCHAIN_ENV_VAR_RAW": "flag_value",
+    "TOOLCHAIN_ENV_VAR_PAREN": "flag_value",
+    "TOOLCHAIN_ENV_VAR_CURLY": "flag_value",
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_PAREN": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_CURLY": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_SIMPLE_VAL_RAW": "hello_world",
+    "INDIRECT_SIMPLE_VAL_PAREN": "hello_world",
+    "INDIRECT_SIMPLE_VAL_CURLY": "hello_world",
+    "INDIRECT_ESCAPED_SIMPLE_VAL_RAW": "$$SIMPLE_VAL",
+    "INDIRECT_ESCAPED_SIMPLE_VAL_PAREN": "$$SIMPLE_VAL",
+    "INDIRECT_ESCAPED_SIMPLE_VAL_CURLY": "$$SIMPLE_VAL",
+    "INDIRECT_LOCATION_VAL_RAW": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_LOCATION_VAL_PAREN": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_LOCATION_VAL_CURLY": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_EXECPATH_VAL_RAW": "$(execpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_EXECPATH_VAL_PAREN": "$(execpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_EXECPATH_VAL_CURLY": "$(execpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_ROOTPATH_VAL_RAW": "$(rootpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_ROOTPATH_VAL_PAREN": "$(rootpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_ROOTPATH_VAL_CURLY": "$(rootpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_RLOCATIONPATH_VAL_RAW": "$(rlocationpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_RLOCATIONPATH_VAL_PAREN": "$(rlocationpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_RLOCATIONPATH_VAL_CURLY": "$(rlocationpath :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_TOOLCHAIN_ENV_VAR_RAW": "flag_value",
+    "INDIRECT_TOOLCHAIN_ENV_VAR_PAREN": "flag_value",
+    "INDIRECT_TOOLCHAIN_ENV_VAR_CURLY": "flag_value",
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_PAREN": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_CURLY": "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+    "MULTI_INDIRECT_RAW": (
+        "hello_world-$$SIMPLE_VAL-$(location :" +
+        _TEST_DEP_TARGET_NAME +
+        ")-$(rlocationpath :" +
+        _TEST_DEP_TARGET_NAME +
+        ")-flag_value-$(location :" +
+        _TEST_DEP_TARGET_NAME +
+        ")"
+    ),
+    "MULTI_INDIRECT_PAREN": (
+        "hello_world-$$SIMPLE_VAL-$(location :" +
+        _TEST_DEP_TARGET_NAME +
+        ")-$(rlocationpath :" +
+        _TEST_DEP_TARGET_NAME +
+        ")-flag_value-$(location :" +
+        _TEST_DEP_TARGET_NAME +
+        ")"
+    ),
+    "MULTI_INDIRECT_CURLY": (
+        "hello_world-$$SIMPLE_VAL-$(location :" +
+        _TEST_DEP_TARGET_NAME +
+        ")-$(rlocationpath :" +
+        _TEST_DEP_TARGET_NAME +
+        ")-flag_value-$(location :" +
+        _TEST_DEP_TARGET_NAME +
+        ")"
+    ),
+    "UNRECOGNIZED_VAR": "$NOPE",
+    "UNRECOGNIZED_FUNC": "$(nope :" + _TEST_DEP_TARGET_NAME + ")",
+}
+
+_EXPECTED_RESOLVED_DICT_WITH_MOCKED_LOCATION = _EXPECTED_RESOLVED_DICT_NO_LOCATION | {
+    "LOCATION_VAL": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "EXECPATH_VAL": _MOCK_EXECPATH_PATH_OF_DUMMY,
+    "ROOTPATH_VAL": _MOCK_ROOTPATH_PATH_OF_DUMMY,
+    "RLOCATIONPATH_VAL": _MOCK_RLOCATIONPATH_PATH_OF_DUMMY,
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_PAREN": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_CURLY": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_LOCATION_VAL_RAW": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_LOCATION_VAL_PAREN": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_LOCATION_VAL_CURLY": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_EXECPATH_VAL_RAW": _MOCK_EXECPATH_PATH_OF_DUMMY,
+    "INDIRECT_EXECPATH_VAL_PAREN": _MOCK_EXECPATH_PATH_OF_DUMMY,
+    "INDIRECT_EXECPATH_VAL_CURLY": _MOCK_EXECPATH_PATH_OF_DUMMY,
+    "INDIRECT_ROOTPATH_VAL_RAW": _MOCK_ROOTPATH_PATH_OF_DUMMY,
+    "INDIRECT_ROOTPATH_VAL_PAREN": _MOCK_ROOTPATH_PATH_OF_DUMMY,
+    "INDIRECT_ROOTPATH_VAL_CURLY": _MOCK_ROOTPATH_PATH_OF_DUMMY,
+    "INDIRECT_RLOCATIONPATH_VAL_RAW": _MOCK_RLOCATIONPATH_PATH_OF_DUMMY,
+    "INDIRECT_RLOCATIONPATH_VAL_PAREN": _MOCK_RLOCATIONPATH_PATH_OF_DUMMY,
+    "INDIRECT_RLOCATIONPATH_VAL_CURLY": _MOCK_RLOCATIONPATH_PATH_OF_DUMMY,
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_PAREN": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_CURLY": _MOCK_LOCATION_PATH_OF_DUMMY,
+    "MULTI_INDIRECT_RAW": (
+        "hello_world-$$SIMPLE_VAL-" +
+        _MOCK_LOCATION_PATH_OF_DUMMY +
+        "-" +
+        _MOCK_RLOCATIONPATH_PATH_OF_DUMMY +
+        "-flag_value-" +
+        _MOCK_LOCATION_PATH_OF_DUMMY
+    ),
+    "MULTI_INDIRECT_PAREN": (
+        "hello_world-$$SIMPLE_VAL-" +
+        _MOCK_LOCATION_PATH_OF_DUMMY +
+        "-" +
+        _MOCK_RLOCATIONPATH_PATH_OF_DUMMY +
+        "-flag_value-" +
+        _MOCK_LOCATION_PATH_OF_DUMMY
+    ),
+    "MULTI_INDIRECT_CURLY": (
+        "hello_world-$$SIMPLE_VAL-" +
+        _MOCK_LOCATION_PATH_OF_DUMMY +
+        "-" +
+        _MOCK_RLOCATIONPATH_PATH_OF_DUMMY +
+        "-flag_value-" +
+        _MOCK_LOCATION_PATH_OF_DUMMY
+    ),
+}
+
+_EXPECTED_RESOLVED_DICT_WITH_GENRULE_LOCATION = _EXPECTED_RESOLVED_DICT_NO_LOCATION | {
+    "LOCATION_VAL": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "EXECPATH_VAL": _GENRULE_EXECPATH_PATH_OF_DUMMY,
+    "ROOTPATH_VAL": _GENRULE_ROOTPATH_PATH_OF_DUMMY,
+    "RLOCATIONPATH_VAL": _GENRULE_RLOCATIONPATH_PATH_OF_DUMMY,
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_PAREN": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "TOOLCHAIN_TO_LOCATION_ENV_VAR_CURLY": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_LOCATION_VAL_RAW": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_LOCATION_VAL_PAREN": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_LOCATION_VAL_CURLY": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_EXECPATH_VAL_RAW": _GENRULE_EXECPATH_PATH_OF_DUMMY,
+    "INDIRECT_EXECPATH_VAL_PAREN": _GENRULE_EXECPATH_PATH_OF_DUMMY,
+    "INDIRECT_EXECPATH_VAL_CURLY": _GENRULE_EXECPATH_PATH_OF_DUMMY,
+    "INDIRECT_ROOTPATH_VAL_RAW": _GENRULE_ROOTPATH_PATH_OF_DUMMY,
+    "INDIRECT_ROOTPATH_VAL_PAREN": _GENRULE_ROOTPATH_PATH_OF_DUMMY,
+    "INDIRECT_ROOTPATH_VAL_CURLY": _GENRULE_ROOTPATH_PATH_OF_DUMMY,
+    "INDIRECT_RLOCATIONPATH_VAL_RAW": _GENRULE_RLOCATIONPATH_PATH_OF_DUMMY,
+    "INDIRECT_RLOCATIONPATH_VAL_PAREN": _GENRULE_RLOCATIONPATH_PATH_OF_DUMMY,
+    "INDIRECT_RLOCATIONPATH_VAL_CURLY": _GENRULE_RLOCATIONPATH_PATH_OF_DUMMY,
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_RAW": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_PAREN": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "INDIRECT_TOOLCHAIN_TO_LOCATION_ENV_VAR_CURLY": _GENRULE_LOCATION_PATH_OF_DUMMY,
+    "MULTI_INDIRECT_RAW": (
+        "hello_world-$$SIMPLE_VAL-" +
+        _GENRULE_LOCATION_PATH_OF_DUMMY +
+        "-" +
+        _GENRULE_RLOCATIONPATH_PATH_OF_DUMMY +
+        "-flag_value-" +
+        _GENRULE_LOCATION_PATH_OF_DUMMY
+    ),
+    "MULTI_INDIRECT_PAREN": (
+        "hello_world-$$SIMPLE_VAL-" +
+        _GENRULE_LOCATION_PATH_OF_DUMMY +
+        "-" +
+        _GENRULE_RLOCATIONPATH_PATH_OF_DUMMY +
+        "-flag_value-" +
+        _GENRULE_LOCATION_PATH_OF_DUMMY
+    ),
+    "MULTI_INDIRECT_CURLY": (
+        "hello_world-$$SIMPLE_VAL-" +
+        _GENRULE_LOCATION_PATH_OF_DUMMY +
+        "-" +
+        _GENRULE_RLOCATIONPATH_PATH_OF_DUMMY +
+        "-flag_value-" +
+        _GENRULE_LOCATION_PATH_OF_DUMMY
+    ),
+}
+
+def _test_toolchain_impl(ctx):
+    _ignore = [ctx]  # @unused
+    return [platform_common.TemplateVariableInfo(_TOOLCHAIN_DICT)]
+
+_test_toolchain = rule(
+    implementation = _test_toolchain_impl,
+)
+
+def _mock_expand_location(input_str):
+    return input_str.replace(
+        "$(location :" + _TEST_DEP_TARGET_NAME + ")",
+        _MOCK_LOCATION_PATH_OF_DUMMY
+    ).replace(
+        "$(execpath :" + _TEST_DEP_TARGET_NAME + ")",
+        _MOCK_EXECPATH_PATH_OF_DUMMY
+    ).replace(
+        "$(rootpath :" + _TEST_DEP_TARGET_NAME + ")",
+        _MOCK_ROOTPATH_PATH_OF_DUMMY
+    ).replace(
+        "$(rlocationpath :" + _TEST_DEP_TARGET_NAME + ")",
+        _MOCK_RLOCATIONPATH_PATH_OF_DUMMY
+    )
+
+def _expand_with_manual_dict_test_impl(ctx):
+    """Test `expansion.expand_with_manual_dict()`"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(_ENV_DICT)
+    toolchain_dict_copy = dict(_TOOLCHAIN_DICT)
+
+    resolved_dict = expansion.expand_with_manual_dict(_TOOLCHAIN_DICT, _ENV_DICT)
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, _ENV_DICT)
+    asserts.equals(env, toolchain_dict_copy, _TOOLCHAIN_DICT)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, _ENV_DICT.keys(), resolved_dict.keys())
+
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in _ENV_DICT.items():
+        expected_val = _EXPECTED_RESOLVED_DICT_NO_LOCATION[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_manual_dict_test = unittest.make(_expand_with_manual_dict_test_impl)
+
+def _expand_with_manual_dict_and_location_test_impl(ctx):
+    """Test `expansion.expand_with_manual_dict_and_location()`"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(_ENV_DICT)
+    toolchain_dict_copy = dict(_TOOLCHAIN_DICT)
+
+    resolved_dict = expansion.expand_with_manual_dict_and_location(
+        _mock_expand_location,
+        _TOOLCHAIN_DICT,
+        _ENV_DICT
+    )
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, _ENV_DICT)
+    asserts.equals(env, toolchain_dict_copy, _TOOLCHAIN_DICT)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, _ENV_DICT.keys(), resolved_dict.keys())
+
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in _ENV_DICT.items():
+        expected_val = _EXPECTED_RESOLVED_DICT_WITH_MOCKED_LOCATION[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_manual_dict_and_location_test = unittest.make(
+    _expand_with_manual_dict_and_location_test_impl,
+)
+
+def _expand_with_toolchains_test_impl(ctx):
+    """Test `expansion.expand_with_toolchains()` without extra dict"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(_ENV_DICT)
+    toolchain_dict_copy = dict(env.ctx.var)
+
+    resolved_dict = expansion.expand_with_toolchains(env.ctx, _ENV_DICT)
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, _ENV_DICT)
+    asserts.equals(env, toolchain_dict_copy, env.ctx.var)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, _ENV_DICT.keys(), resolved_dict.keys())
+
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in _ENV_DICT.items():
+        expected_val = _EXPECTED_RESOLVED_DICT_NO_LOCATION[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_toolchains_test = unittest.make(_expand_with_toolchains_test_impl)
+
+def _expand_with_toolchains_with_additional_dict_test_impl(ctx):
+    """Test `expansion.expand_with_toolchains()` with extra dict"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(_ENV_DICT)
+    toolchain_dict_copy = dict(env.ctx.var)
+
+    additional_lookup_dict = {
+        "NOPE": "naw, it's fine now.",
+    }
+
+    resolved_dict = expansion.expand_with_toolchains(
+        env.ctx,
+        _ENV_DICT,
+        additional_lookup_dict = additional_lookup_dict
+    )
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, _ENV_DICT)
+    asserts.equals(env, toolchain_dict_copy, env.ctx.var)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, _ENV_DICT.keys(), resolved_dict.keys())
+
+    updated_expected_dict = _EXPECTED_RESOLVED_DICT_NO_LOCATION | {
+        "UNRECOGNIZED_VAR": "naw, it's fine now.",
+    }
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in _ENV_DICT.items():
+        expected_val = updated_expected_dict[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_toolchains_with_additional_dict_test = unittest.make(
+    _expand_with_toolchains_with_additional_dict_test_impl
+)
+
+def _expand_with_toolchains_attr_test_impl(ctx):
+    """Test `expansion.expand_with_toolchains_attr()` without extra dict"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(env.ctx.attr.env)
+    toolchain_dict_copy = dict(env.ctx.var)
+
+    resolved_dict = expansion.expand_with_toolchains_attr(env.ctx)
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, env.ctx.attr.env)
+    asserts.equals(env, toolchain_dict_copy, env.ctx.var)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, env.ctx.attr.env.keys(), resolved_dict.keys())
+
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in env.ctx.attr.env.items():
+        expected_val = _EXPECTED_RESOLVED_DICT_NO_LOCATION[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_toolchains_attr_test = unittest.make(
+    _expand_with_toolchains_attr_test_impl,
+    attrs = {
+        "env": attr.string_dict(),
+    }
+)
+
+def _expand_with_toolchains_attr_with_additional_dict_test_impl(ctx):
+    """Test `expansion.expand_with_toolchains_attr()` with extra dict"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(env.ctx.attr.env)
+    toolchain_dict_copy = dict(env.ctx.var)
+
+    additional_lookup_dict = {
+        "NOPE": "naw, it's fine now.",
+    }
+
+    resolved_dict = expansion.expand_with_toolchains_attr(
+        env.ctx,
+        additional_lookup_dict = additional_lookup_dict
+    )
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, env.ctx.attr.env)
+    asserts.equals(env, toolchain_dict_copy, env.ctx.var)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, env.ctx.attr.env.keys(), resolved_dict.keys())
+
+    updated_expected_dict = _EXPECTED_RESOLVED_DICT_NO_LOCATION | {
+        "UNRECOGNIZED_VAR": "naw, it's fine now.",
+    }
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in env.ctx.attr.env.items():
+        expected_val = updated_expected_dict[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_toolchains_attr_with_additional_dict_test = unittest.make(
+    _expand_with_toolchains_attr_with_additional_dict_test_impl,
+    attrs = {
+        "env": attr.string_dict(),
+    }
+)
+
+def _expand_with_toolchains_and_location_test_impl(ctx):
+    """Test `expansion.expand_with_toolchains_and_location()` without extra dict"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(_ENV_DICT)
+    toolchain_dict_copy = dict(env.ctx.var)
+
+    resolved_dict = expansion.expand_with_toolchains_and_location(
+        env.ctx,
+        [ctx.attr.target],
+        _ENV_DICT
+    )
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, _ENV_DICT)
+    asserts.equals(env, toolchain_dict_copy, env.ctx.var)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, _ENV_DICT.keys(), resolved_dict.keys())
+
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in _ENV_DICT.items():
+        expected_val = _EXPECTED_RESOLVED_DICT_WITH_GENRULE_LOCATION[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_toolchains_and_location_test = unittest.make(
+    _expand_with_toolchains_and_location_test_impl,
+    attrs = {
+        "target": attr.label(),
+    }
+)
+
+def _expand_with_toolchains_and_location_with_additional_dict_test_impl(ctx):
+    """Test `expansion.expand_with_toolchains_and_location()` with extra dict"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(_ENV_DICT)
+    toolchain_dict_copy = dict(env.ctx.var)
+
+    additional_lookup_dict = {
+        "NOPE": "naw, it's fine now.",
+    }
+
+    resolved_dict = expansion.expand_with_toolchains_and_location(
+        env.ctx,
+        [ctx.attr.target],
+        _ENV_DICT,
+        additional_lookup_dict = additional_lookup_dict
+    )
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, _ENV_DICT)
+    asserts.equals(env, toolchain_dict_copy, env.ctx.var)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, _ENV_DICT.keys(), resolved_dict.keys())
+
+    updated_expected_dict = _EXPECTED_RESOLVED_DICT_WITH_GENRULE_LOCATION | {
+        "UNRECOGNIZED_VAR": "naw, it's fine now.",
+    }
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in _ENV_DICT.items():
+        expected_val = updated_expected_dict[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_toolchains_and_location_with_additional_dict_test = unittest.make(
+    _expand_with_toolchains_and_location_with_additional_dict_test_impl,
+    attrs = {
+        "target": attr.label(),
+    }
+)
+
+def _expand_with_toolchains_and_location_attr_test_impl(ctx):
+    """Test `expansion.expand_with_toolchains_and_location_attr()` without extra dict"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(env.ctx.attr.env)
+    toolchain_dict_copy = dict(env.ctx.var)
+
+    resolved_dict = expansion.expand_with_toolchains_and_location_attr(env.ctx)
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, env.ctx.attr.env)
+    asserts.equals(env, toolchain_dict_copy, env.ctx.var)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, env.ctx.attr.env.keys(), resolved_dict.keys())
+
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in env.ctx.attr.env.items():
+        expected_val = _EXPECTED_RESOLVED_DICT_WITH_GENRULE_LOCATION[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_toolchains_and_location_attr_test = unittest.make(
+    _expand_with_toolchains_and_location_attr_test_impl,
+    attrs = {
+        "deps": attr.label_list(),
+        "env": attr.string_dict(),
+    }
+)
+
+def _expand_with_toolchains_and_location_attr_with_additional_dict_test_impl(ctx):
+    """Test `expansion.expand_with_toolchains_and_location_attr()` with extra dict"""
+    env = unittest.begin(ctx)
+
+    env_dict_copy = dict(env.ctx.attr.env)
+    toolchain_dict_copy = dict(env.ctx.var)
+
+    additional_lookup_dict = {
+        "NOPE": "naw, it's fine now.",
+    }
+
+    resolved_dict = expansion.expand_with_toolchains_and_location_attr(
+        env.ctx,
+        additional_lookup_dict = additional_lookup_dict
+    )
+
+    # Check that the inputs are not mutated.
+    asserts.equals(env, env_dict_copy, env.ctx.attr.env)
+    asserts.equals(env, toolchain_dict_copy, env.ctx.var)
+
+    # Check that the output has exact same key set as original input.
+    asserts.equals(env, env.ctx.attr.env.keys(), resolved_dict.keys())
+
+    updated_expected_dict = _EXPECTED_RESOLVED_DICT_WITH_GENRULE_LOCATION | {
+        "UNRECOGNIZED_VAR": "naw, it's fine now.",
+    }
+    # Check all output resolved values against expected resolved values.
+    for env_key, _ in env.ctx.attr.env.items():
+        expected_val = updated_expected_dict[env_key]
+        resolved_val = resolved_dict[env_key]
+        asserts.equals(env, expected_val, resolved_val)
+
+    return unittest.end(env)
+
+_expand_with_toolchains_and_location_attr_with_additional_dict_test = unittest.make(
+    _expand_with_toolchains_and_location_attr_with_additional_dict_test_impl,
+    attrs = {
+        "deps": attr.label_list(),
+        "env": attr.string_dict(),
+    }
+)
+
+# buildifier: disable=unnamed-macro
+def expansion_test_suite():
+    """Creates the test targets and test suite for expansion.bzl tests."""
+
+    native.genrule(
+        name = _TEST_DEP_TARGET_NAME,
+        outs = ["dummy.txt"],
+        cmd = "touch $@",
+    )
+
+    _test_toolchain(
+        name = "expansion_tests__test_toolchain",
+    )
+
+    _expand_with_manual_dict_test(
+        name = "expansion_tests__expand_with_manual_dict_test",
+    )
+    _expand_with_manual_dict_and_location_test(
+        name = "expansion_tests__expand_with_manual_dict_and_location_test",
+    )
+    _expand_with_toolchains_test(
+        name = "expansion_tests__expand_with_toolchains_test",
+        toolchains = [":expansion_tests__test_toolchain"],
+    )
+    _expand_with_toolchains_with_additional_dict_test(
+        name = "expansion_tests__expand_with_toolchains_with_additional_dict_test",
+        toolchains = [":expansion_tests__test_toolchain"],
+    )
+    _expand_with_toolchains_attr_test(
+        name = "expansion_tests__expand_with_toolchains_attr_test",
+        env = _ENV_DICT,
+        toolchains = [":expansion_tests__test_toolchain"],
+    )
+    _expand_with_toolchains_attr_with_additional_dict_test(
+        name = "expansion_tests__expand_with_toolchains_attr_with_additional_dict_test",
+        env = _ENV_DICT,
+        toolchains = [":expansion_tests__test_toolchain"],
+    )
+    _expand_with_toolchains_and_location_test(
+        name = "expansion_tests__expand_with_toolchains_and_location_test",
+        target = ":" + _TEST_DEP_TARGET_NAME,
+        toolchains = [":expansion_tests__test_toolchain"],
+    )
+    _expand_with_toolchains_and_location_with_additional_dict_test(
+        name = "expansion_tests__expand_with_toolchains_and_location_with_additional_dict_test",
+        target = ":" + _TEST_DEP_TARGET_NAME,
+        toolchains = [":expansion_tests__test_toolchain"],
+    )
+    _expand_with_toolchains_and_location_attr_test(
+        name = "expansion_tests__expand_with_toolchains_and_location_attr_test",
+        deps = [":" + _TEST_DEP_TARGET_NAME],
+        env = _ENV_DICT,
+        toolchains = [":expansion_tests__test_toolchain"],
+    )
+    _expand_with_toolchains_and_location_attr_with_additional_dict_test(
+        name = "expansion_tests__expand_with_toolchains_and_location_attr_with_additional_dict_test",
+        deps = [":" + _TEST_DEP_TARGET_NAME],
+        env = _ENV_DICT,
+        toolchains = [":expansion_tests__test_toolchain"],
+    )
+
+    native.test_suite(
+        name = "expansion_tests",
+        tests = [
+            ":expansion_tests__expand_with_manual_dict_test",
+            ":expansion_tests__expand_with_manual_dict_and_location_test",
+            ":expansion_tests__expand_with_toolchains_test",
+            ":expansion_tests__expand_with_toolchains_with_additional_dict_test",
+            ":expansion_tests__expand_with_toolchains_attr_test",
+            ":expansion_tests__expand_with_toolchains_attr_with_additional_dict_test",
+            ":expansion_tests__expand_with_toolchains_and_location_test",
+            ":expansion_tests__expand_with_toolchains_and_location_with_additional_dict_test",
+            ":expansion_tests__expand_with_toolchains_and_location_attr_test",
+            ":expansion_tests__expand_with_toolchains_and_location_attr_with_additional_dict_test",
+        ],
+    )


### PR DESCRIPTION
The built-in functionality (exposed Skylark methods on `ctx`) for expanding environment variables leaves a lot of implementation to do in `bzl` files. This PR adds in that missing functionality for easy reuse with a new `expansion` struct. `expansion` has various methods for expanding environment variables with a flexible API.

The existing APIs handle only one piece at a time:
* `ctx.expand_location()` only handles `$(location ...)` (and similar) expansion. It does not handle any "make variable" expansion (no expansion from `TemplateVariableInfo` or other providers via toolchains).
* `ctx.expand_make_variables()` only handles make variables. If it encounters `$(location ...)` (or similar), it [errors out with no means of recovery](https://github.com/bazelbuild/bazel/blob/addf41bce1f26e8bc4bd0b09cb2fbffbb0446f25/src/main/java/com/google/devtools/build/lib/analysis/ConfigurationMakeVariableContext.java#L136). This method is also marked as deprecated, with `ctx.var` listed as the preferred API.
* `ctx.var` is a simple dictionary, which contains resolved mappings based on toolchains. However, being a simple data structure (not a function) leaves recursive functionality and/or integration with `ctx.expand_location()` to be implemented by hand (or in this PR).

Many internal systems make use of functionality that fully resolves both make variables and `$(location ...)` (and does so recursively). This is done with `ruleContext.getExpander().withDataLocations()` ([example](https://github.com/bazelbuild/bazel/blob/addf41bce1f26e8bc4bd0b09cb2fbffbb0446f25/src/main/java/com/google/devtools/build/lib/analysis/RunfilesSupport.java#L522)). However, this is never exposed to skylark. This means that built-in rules will have the `env` attribute fully expanded, but custom rules cannot (easily).

The above mentioned methods have their own (somewhat duplicated) implementations ([`ctx.expand_location()`](https://github.com/bazelbuild/bazel/blob/addf41bce1f26e8bc4bd0b09cb2fbffbb0446f25/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java#L1011), [`ctx.expand_make_variables()`](https://github.com/bazelbuild/bazel/blob/addf41bce1f26e8bc4bd0b09cb2fbffbb0446f25/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java#L964), [`ctx.var`](https://github.com/bazelbuild/bazel/blob/addf41bce1f26e8bc4bd0b09cb2fbffbb0446f25/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java#L823)). Note the identical `ConfigurationMakeVariableContext` initialization [here](https://github.com/bazelbuild/bazel/blob/addf41bce1f26e8bc4bd0b09cb2fbffbb0446f25/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleContext.java#L949) and [here](https://github.com/bazelbuild/bazel/blob/36fa60b1805faa7da2c4b5330b4b186740f5f00d/src/main/java/com/google/devtools/build/lib/analysis/RuleContext.java#L978) -- identical except for the use of `additionalSubstitutionsMap`, which could have been delegated (similar to the impl of `LocationTemplateContext`). Also note the separate/duplicated parsing implementations in [`LocationTemplateContext`](https://github.com/bazelbuild/bazel/blob/addf41bce1f26e8bc4bd0b09cb2fbffbb0446f25/src/main/java/com/google/devtools/build/lib/analysis/stringtemplate/TemplateExpander.java#L77) and in [`LocationExpander`](https://github.com/bazelbuild/bazel/blob/36fa60b1805faa7da2c4b5330b4b186740f5f00d/src/main/java/com/google/devtools/build/lib/analysis/LocationExpander.java#L179).

This PR tries to avoid more duplicate implementations (which can't really happen anyway; as this is in external Skylark, not Java / Bazel runtime). These new methods make use of `ctx.expand_location()` and `ctx.var` to allow fully recursive variable expansion that incorporates both inputs (toolchains and `location`). The methods avoid copies/string mutations/extra loops when necessary to ensure that the functions can run quickly. The methods' API allows for manual/direct data structures (lists/dicts) as input, or for pulling values directly from `ctx`. `tests/expansion_tests.bzl` added to test all added methods.

This PR is being submitted here so that it can be reused (instead of copied in many repos). It is also preferable to add functionality here in Skylib, instead of (or in addition to) any changes in the [Bazel repo](https://github.com/bazelbuild/bazel) so that it can be more easily pulled into projects with a pinned Bazel version.

Please feel free to leave comments or suggestion on ways to improve this PR, or let me know if you have any questions. Thanks!