### PR TITLE
expand_template: do not output_to_genfiles

### DIFF
--- a/rules/expand_template.bzl
+++ b/rules/expand_template.bzl
@@ -46,5 +46,4 @@ explicitly add delimiters to the key strings, for example "{KEY}" or "@KEY@"."""
             doc = "The destination of the expanded file.",
         ),
     },
-    output_to_genfiles = True,
 )


### PR DESCRIPTION
output_to_genfiles is deprecated unless needed for backwards compatibility with legacy rules (see https://bazel.build/rules/lib/globals/bzl#rule)