### PR TITLE
Improve compatibility with Bazel 6.

### DIFF
--- a/lib/modules.bzl
+++ b/lib/modules.bzl
@@ -46,9 +46,13 @@ def _as_extension(macro, doc = None):
         # deterministic.
         return _use_all_repos(module_ctx, reproducible = True)
 
+    kwargs = {}
+    if doc != None:
+        kwargs["doc"] = doc
+
     return module_extension(
         implementation = _ext_impl,
-        doc = doc,
+        **kwargs
     )
 
 def _use_all_repos(module_ctx, reproducible = False):


### PR DESCRIPTION
In Bazel 6, the doc parameter of the module_extension function doesn’t accept None; cf. https://bazel.build/versions/6.5.0/rules/lib/globals#module_extension vs. https://bazel.build/versions/7.0.0/rules/lib/globals/bzl#module_extension. Instead of passing None in that case, just don’t pass the argument at all and use the respective default.