### PR TITLE
Improve CI setup: add tests for Bazel 5.x and 6.x (with and without bzlmod); use Ubuntu 20.04 as main platform

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,18 +1,22 @@
 ---
+.reusable_build_flags: &reusable_build_flags
+  ? "--incompatible_config_setting_private_default_visibility"
+  ? "--incompatible_disallow_empty_glob"
+
+.reusable_test_flags: &reusable_test_flags
+  <<: *reusable_build_flags
+  ? "--test_env=PATH"
+
+.reusable_targets: &reusable_targets
+  ? "--"
+  ? "//..."
+  ? "@bazel_skylib_gazelle_plugin//..."
+
 .reusable_config: &reusable_config
-  build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
-  test_flags:
-    - "--test_env=PATH"
-  build_targets:
-    - "--"
-    - "//..."
-    - "@bazel_skylib_gazelle_plugin//..."
-  test_targets:
-    - "--"
-    - "//..."
-    - "@bazel_skylib_gazelle_plugin//..."
+  build_flags: *reusable_build_flags
+  test_flags: *reusable_test_flags
+  build_targets: *reusable_targets
+  test_targets: *reusable_targets
 
 tasks:
   ubuntu2004_bazel5:
@@ -26,6 +30,14 @@ tasks:
     name: "Bazel 6.x"
     platform: ubuntu2004
     bazel: 6.x
+    build_targets:
+    <<: *reusable_targets
+    # rules_pkg fails with --noenable_bzlmod
+    ? "-//distribution/..."
+    test_targets:
+    <<: *reusable_targets
+    # rules_pkg fails with --noenable_bzlmod
+    ? "-//distribution/..."
 
   ubuntu2004_bazel6_enable_bzlmod:
     <<: *reusable_config
@@ -33,12 +45,11 @@ tasks:
     platform: ubuntu2004
     bazel: 6.x
     build_flags:
-    - "--enable_bzlmod"
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
+    <<: *reusable_build_flags
+    ? "--enable_bzlmod"
     test_flags:
-    - "--enable_bzlmod"
-    - "--test_env=PATH"
+    <<: *reusable_test_flags
+    ? "--enable_bzlmod"
 
   ubuntu2004_latest:
     <<: *reusable_config
@@ -52,11 +63,19 @@ tasks:
     platform: ubuntu2004
     bazel: latest
     build_flags:
-    - "--noenable_bzlmod"
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
+    <<: *reusable_build_flags
+    ? "--noenable_bzlmod"
     test_flags:
-    - "--test_env=PATH"
+    <<: *reusable_test_flags
+    ? "--noenable_bzlmod"
+    build_targets:
+    <<: *reusable_targets
+    # rules_pkg fails with --noenable_bzlmod
+    ? "-//distribution/..."
+    test_targets:
+    <<: *reusable_targets
+    # rules_pkg fails with --noenable_bzlmod
+    ? "-//distribution/..."
 
   ubuntu1804_latest:
     <<: *reusable_config
@@ -65,26 +84,18 @@ tasks:
     bazel: latest
 
   ubuntu1604_latest:
+    <<: *reusable_config
     name: "Latest Bazel"
     platform: ubuntu1604
     bazel: latest
-    build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
     build_targets:
-    - "--"
-    - "//..."
-    - "@bazel_skylib_gazelle_plugin//..."
+    <<: *reusable_targets
     # //distribution requires Python >= 3.6 for some rules_pkg scripts; Ubuntu 16.04 has Python 3.5
-    - "-//distribution/..."
-    test_flags:
-    - "--test_env=PATH"
+    ? "-//distribution/..."
     test_targets:
-    - "--"
-    - "//..."
-    - "@bazel_skylib_gazelle_plugin//..."
+    <<: *reusable_targets
     # //distribution requires Python >= 3.6 for some rules_pkg scripts; Ubuntu 16.04 has Python 3.5
-    - "-//distribution/..."
+    ? "-//distribution/..."
 
   macos_latest:
     <<: *reusable_config
@@ -97,14 +108,12 @@ tasks:
     name: "Latest Bazel"
     platform: windows
     bazel: latest
-    build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
     test_flags:
+    <<: *reusable_test_flags
     # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
     # https://github.com/bazelbuild/bazel/issues/7761 is fixed
-    - "--test_env=LOCALAPPDATA"
-    - "--test_tag_filters=-no_windows"
+    ? "--test_env=LOCALAPPDATA"
+    ? "--test_tag_filters=-no_windows"
 
   ubuntu2004_last_green:
     <<: *reusable_config
@@ -123,13 +132,11 @@ tasks:
     name: "Last Green Bazel"
     platform: windows
     bazel: last_green
-    build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
     test_flags:
+    <<: *reusable_test_flags
     # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
     # https://github.com/bazelbuild/bazel/issues/7761 is fixed
-    - "--test_env=LOCALAPPDATA"
-    - "--test_tag_filters=-no_windows"
+    ? "--test_env=LOCALAPPDATA"
+    ? "--test_tag_filters=-no_windows"
 
 buildifier: latest

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,5 +1,10 @@
 ---
 .reusable_config: &reusable_config
+  build_flags:
+    - "--incompatible_config_setting_private_default_visibility"
+    - "--incompatible_disallow_empty_glob"
+  test_flags:
+    - "--test_env=PATH"
   build_targets:
     - "--"
     - "//..."
@@ -10,16 +15,54 @@
     - "@bazel_skylib_gazelle_plugin//..."
 
 tasks:
+  ubuntu2004_bazel5:
+    <<: *reusable_config
+    name: "Bazel 5.x"
+    platform: ubuntu2004
+    bazel: 5.x
+
+  ubuntu2004_bazel6:
+    <<: *reusable_config
+    name: "Bazel 6.x"
+    platform: ubuntu2004
+    bazel: 6.x
+
+  ubuntu2004_bazel6_enable_bzlmod:
+    <<: *reusable_config
+    name: "Bazel 6.x with --enable_bzlmod"
+    platform: ubuntu2004
+    bazel: 6.x
+    build_flags:
+    - "--enable_bzlmod"
+    - "--incompatible_config_setting_private_default_visibility"
+    - "--incompatible_disallow_empty_glob"
+    test_flags:
+    - "--enable_bzlmod"
+    - "--test_env=PATH"
+
+  ubuntu2004_latest:
+    <<: *reusable_config
+    name: "Latest Bazel"
+    platform: ubuntu2004
+    bazel: latest
+
+  ubuntu2004_latest_noenable_bzlmod:
+    <<: *reusable_config
+    name: "Latest Bazel with --noenable_bzlmod"
+    platform: ubuntu2004
+    bazel: latest
+    build_flags:
+    - "--noenable_bzlmod"
+    - "--incompatible_config_setting_private_default_visibility"
+    - "--incompatible_disallow_empty_glob"
+    test_flags:
+    - "--test_env=PATH"
+
   ubuntu1804_latest:
     <<: *reusable_config
     name: "Latest Bazel"
     platform: ubuntu1804
     bazel: latest
-    build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
-    test_flags:
-    - "--test_env=PATH"
 
   ubuntu1604_latest:
     name: "Latest Bazel"
@@ -48,11 +91,6 @@ tasks:
     name: "Latest Bazel"
     platform: macos
     bazel: latest
-    build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
-    test_flags:
-    - "--test_env=PATH"
 
   windows_latest:
     <<: *reusable_config
@@ -68,49 +106,17 @@ tasks:
     - "--test_env=LOCALAPPDATA"
     - "--test_tag_filters=-no_windows"
 
-  ubuntu1804_last_green:
+  ubuntu2004_last_green:
     <<: *reusable_config
     name: "Last Green Bazel"
     platform: ubuntu1804
     bazel: last_green
-    build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
-    test_flags:
-    - "--test_env=PATH"
-
-  ubuntu1604_last_green:
-    name: "Last Green Bazel"
-    platform: ubuntu1604
-    bazel: last_green
-    build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
-    build_targets:
-    - "--"
-    - "//..."
-    - "@bazel_skylib_gazelle_plugin//..."
-    # //distribution requires Python >= 3.6 for some rules_pkg scripts; Ubuntu 16.04 has Python 3.5
-    - "-//distribution/..."
-    test_flags:
-    - "--test_env=PATH"
-    test_targets:
-    - "--"
-    - "//..."
-    - "@bazel_skylib_gazelle_plugin//..."
-    # //distribution requires Python >= 3.6 for some rules_pkg scripts; Ubuntu 16.04 has Python 3.5
-    - "-//distribution/..."
 
   macos_last_green:
     <<: *reusable_config
     name: "Last Green Bazel"
     platform: macos
     bazel: last_green
-    build_flags:
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
-    test_flags:
-    - "--test_env=PATH"
 
   windows_last_green:
     <<: *reusable_config
@@ -125,18 +131,5 @@ tasks:
     # https://github.com/bazelbuild/bazel/issues/7761 is fixed
     - "--test_env=LOCALAPPDATA"
     - "--test_tag_filters=-no_windows"
-
-  ubuntu1804_last_green_bzlmod:
-    <<: *reusable_config
-    name: "Last Green Bazel (with bzlmod)"
-    platform: ubuntu1804
-    bazel: last_green
-    build_flags:
-    - "--enable_bzlmod"
-    - "--incompatible_config_setting_private_default_visibility"
-    - "--incompatible_disallow_empty_glob"
-    test_flags:
-    - "--enable_bzlmod"
-    - "--test_env=PATH"
 
 buildifier: latest

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,4 +1,10 @@
 ---
+matrix:
+  platform:
+    - ubuntu1804
+    - ubuntu2004
+    - macos
+
 .reusable_build_flags: &reusable_build_flags
   ? "--incompatible_config_setting_private_default_visibility"
   ? "--incompatible_disallow_empty_glob"
@@ -31,13 +37,13 @@ tasks:
     platform: ubuntu2004
     bazel: 6.x
     build_targets:
-    <<: *reusable_targets
-    # rules_pkg fails with --noenable_bzlmod
-    ? "-//distribution/..."
+      <<: *reusable_targets
+      # rules_pkg fails with --noenable_bzlmod
+      ? "-//distribution/..."
     test_targets:
-    <<: *reusable_targets
-    # rules_pkg fails with --noenable_bzlmod
-    ? "-//distribution/..."
+      <<: *reusable_targets
+      # rules_pkg fails with --noenable_bzlmod
+      ? "-//distribution/..."
 
   ubuntu2004_bazel6_enable_bzlmod:
     <<: *reusable_config
@@ -45,16 +51,16 @@ tasks:
     platform: ubuntu2004
     bazel: 6.x
     build_flags:
-    <<: *reusable_build_flags
-    ? "--enable_bzlmod"
+      <<: *reusable_build_flags
+      ? "--enable_bzlmod"
     test_flags:
-    <<: *reusable_test_flags
-    ? "--enable_bzlmod"
+      <<: *reusable_test_flags
+      ? "--enable_bzlmod"
 
-  ubuntu2004_latest:
+  latest:
     <<: *reusable_config
     name: "Latest Bazel"
-    platform: ubuntu2004
+    platform: ${{ platform }}
     bazel: latest
 
   ubuntu2004_latest_noenable_bzlmod:
@@ -63,25 +69,19 @@ tasks:
     platform: ubuntu2004
     bazel: latest
     build_flags:
-    <<: *reusable_build_flags
-    ? "--noenable_bzlmod"
+      <<: *reusable_build_flags
+      ? "--noenable_bzlmod"
     test_flags:
-    <<: *reusable_test_flags
-    ? "--noenable_bzlmod"
+      <<: *reusable_test_flags
+      ? "--noenable_bzlmod"
     build_targets:
-    <<: *reusable_targets
-    # rules_pkg fails with --noenable_bzlmod
-    ? "-//distribution/..."
+      <<: *reusable_targets
+      # rules_pkg fails with --noenable_bzlmod
+      ? "-//distribution/..."
     test_targets:
-    <<: *reusable_targets
-    # rules_pkg fails with --noenable_bzlmod
-    ? "-//distribution/..."
-
-  ubuntu1804_latest:
-    <<: *reusable_config
-    name: "Latest Bazel"
-    platform: ubuntu1804
-    bazel: latest
+      <<: *reusable_targets
+      # rules_pkg fails with --noenable_bzlmod
+      ? "-//distribution/..."
 
   ubuntu1604_latest:
     <<: *reusable_config
@@ -89,19 +89,13 @@ tasks:
     platform: ubuntu1604
     bazel: latest
     build_targets:
-    <<: *reusable_targets
-    # //distribution requires Python >= 3.6 for some rules_pkg scripts; Ubuntu 16.04 has Python 3.5
-    ? "-//distribution/..."
+      <<: *reusable_targets
+      # //distribution requires Python >= 3.6 for some rules_pkg scripts; Ubuntu 16.04 has Python 3.5
+      ? "-//distribution/..."
     test_targets:
-    <<: *reusable_targets
-    # //distribution requires Python >= 3.6 for some rules_pkg scripts; Ubuntu 16.04 has Python 3.5
-    ? "-//distribution/..."
-
-  macos_latest:
-    <<: *reusable_config
-    name: "Latest Bazel"
-    platform: macos
-    bazel: latest
+      <<: *reusable_targets
+      # //distribution requires Python >= 3.6 for some rules_pkg scripts; Ubuntu 16.04 has Python 3.5
+      ? "-//distribution/..."
 
   windows_latest:
     <<: *reusable_config
@@ -109,22 +103,16 @@ tasks:
     platform: windows
     bazel: latest
     test_flags:
-    <<: *reusable_test_flags
-    # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
-    # https://github.com/bazelbuild/bazel/issues/7761 is fixed
-    ? "--test_env=LOCALAPPDATA"
-    ? "--test_tag_filters=-no_windows"
+      <<: *reusable_test_flags
+      # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
+      # https://github.com/bazelbuild/bazel/issues/7761 is fixed
+      ? "--test_env=LOCALAPPDATA"
+      ? "--test_tag_filters=-no_windows"
 
-  ubuntu2004_last_green:
+  last_green:
     <<: *reusable_config
     name: "Last Green Bazel"
-    platform: ubuntu1804
-    bazel: last_green
-
-  macos_last_green:
-    <<: *reusable_config
-    name: "Last Green Bazel"
-    platform: macos
+    platform: ${{ platform }}
     bazel: last_green
 
   windows_last_green:
@@ -133,10 +121,10 @@ tasks:
     platform: windows
     bazel: last_green
     test_flags:
-    <<: *reusable_test_flags
-    # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
-    # https://github.com/bazelbuild/bazel/issues/7761 is fixed
-    ? "--test_env=LOCALAPPDATA"
-    ? "--test_tag_filters=-no_windows"
+      <<: *reusable_test_flags
+      # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
+      # https://github.com/bazelbuild/bazel/issues/7761 is fixed
+      ? "--test_env=LOCALAPPDATA"
+      ? "--test_tag_filters=-no_windows"
 
 buildifier: latest


### PR DESCRIPTION
Adding tests with Bazel 5 and 6 will let us catch problems like #499; and Ubuntu 18.04 is getting old