### PR TITLE
Re-add `licenses()` - internal license checker still requires it :/

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,8 @@ license(
     license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
 )
 
+licenses(["notice"])
+
 # buildifier: disable=skylark-comment
 # gazelle:exclude skylark_library.bzl
 

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -8,6 +8,8 @@ package(
     default_visibility = ["//visibility:private"],
 )
 
+licenses(["notice"])
+
 remove_internal_only(
     name = "distro_workspace",
     src = "//:WORKSPACE",

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -2,6 +2,8 @@ load("//docs/private:stardoc_with_diff_test.bzl", "stardoc_with_diff_test", "upd
 
 package(default_applicable_licenses = ["//:license"])
 
+licenses(["notice"])
+
 stardoc_with_diff_test(
     name = "analysis_test",
     bzl_library_target = "//rules:analysis_test",

--- a/docs/private/BUILD
+++ b/docs/private/BUILD
@@ -1,3 +1,5 @@
 # This package only contains source targets
 
 package(default_applicable_licenses = ["//:license"])
+
+licenses(["notice"])

--- a/gazelle/BUILD
+++ b/gazelle/BUILD
@@ -1,13 +1,15 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_license//rules:license.bzl", "license")
 
-package(default_applicable_licenses = ["@bazel_skylib//:license"])
+package(default_applicable_licenses = ["//:license"])
 
 license(
     name = "license",
     package_name = "bazelbuild/bazel_skylib_gazelle_module",
     license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
 )
+
+licenses(["notice"])
 
 exports_files(["WORKSPACE.bzlmod"])
 

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -5,6 +5,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+licenses(["notice"])
+
 # export bzl files for the documentation
 exports_files(
     glob(["*.bzl"]),

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -5,6 +5,8 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+licenses(["notice"])
+
 bzl_library(
     name = "analysis_test",
     srcs = ["analysis_test.bzl"],

--- a/rules/private/BUILD
+++ b/rules/private/BUILD
@@ -2,6 +2,8 @@ load("//:bzl_library.bzl", "bzl_library")
 
 package(default_applicable_licenses = ["//:license"])
 
+licenses(["notice"])
+
 bzl_library(
     name = "copy_common",
     srcs = ["copy_common.bzl"],

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -20,6 +20,8 @@ package(
     default_testonly = 1,
 )
 
+licenses(["notice"])
+
 exports_files(
     ["unittest.bash"],
     visibility = ["//tests:__subpackages__"],

--- a/tests/bzl_library/BUILD
+++ b/tests/bzl_library/BUILD
@@ -6,6 +6,8 @@ package(
     default_testonly = 1,
 )
 
+licenses(["notice"])
+
 filegroup(
     name = "a",
     srcs = ["testdata/a.bzl"],

--- a/tests/common_settings/BUILD
+++ b/tests/common_settings/BUILD
@@ -5,6 +5,8 @@ package(
     default_testonly = 1,
 )
 
+licenses(["notice"])
+
 int_flag(
     name = "my_int_flag",
     build_setting_default = 42,

--- a/tests/copy_directory/BUILD.bazel
+++ b/tests/copy_directory/BUILD.bazel
@@ -8,6 +8,8 @@ package(
     default_testonly = 1,
 )
 
+licenses(["notice"])
+
 # Copy of directory containing files a and b, and a subdir containing c
 copy_directory(
     name = "copy_of_dir_with_subdir",

--- a/tests/copy_file/BUILD
+++ b/tests/copy_file/BUILD
@@ -38,6 +38,8 @@ package(
     default_testonly = 1,
 )
 
+licenses(["notice"])
+
 sh_test(
     name = "copy_file_tests",
     srcs = ["copy_file_tests.sh"],

--- a/tests/diff_test/BUILD
+++ b/tests/diff_test/BUILD
@@ -7,6 +7,8 @@ package(
     default_testonly = 1,
 )
 
+licenses(["notice"])
+
 sh_test(
     name = "diff_test_tests",
     srcs = ["diff_test_tests.sh"],

--- a/tests/select_file/BUILD
+++ b/tests/select_file/BUILD
@@ -6,6 +6,8 @@ package(
     default_testonly = 1,
 )
 
+licenses(["notice"])
+
 filegroup(
     name = "fg",
     srcs = [

--- a/tests/write_file/BUILD
+++ b/tests/write_file/BUILD
@@ -40,6 +40,8 @@ package(
     default_testonly = 1,
 )
 
+licenses(["notice"])
+
 sh_test(
     name = "write_file_tests",
     srcs = ["write_file_tests.sh"],

--- a/toolchains/unittest/BUILD
+++ b/toolchains/unittest/BUILD
@@ -2,6 +2,8 @@ load("//lib:unittest.bzl", "TOOLCHAIN_TYPE", "unittest_toolchain")
 
 package(default_applicable_licenses = ["//:license"])
 
+licenses(["notice"])
+
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
And take the opportunity to fix default_applicable_licenses in the gazelle plugin