### PR TITLE
Make only root test_deps externally visible

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -99,6 +99,7 @@ filegroup(
     name = "test_deps",
     testonly = True,
     srcs = ["BUILD"] + glob(["*.bzl"]),
+    visibility = ["//:__subpackages__"],  # Needs skylib's root BUILD file for default_applicable_licenses
 )
 
 # The files needed for distribution

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -69,6 +69,7 @@ filegroup(
     srcs = [
         "BUILD",
     ] + glob(["*.bzl"]),
+    visibility = ["//:__subpackages__"],  # Needs skylib's root BUILD file for default_applicable_licenses
 )
 
 # The files needed for distribution

--- a/toolchains/unittest/BUILD
+++ b/toolchains/unittest/BUILD
@@ -56,7 +56,7 @@ filegroup(
     srcs = [
         "BUILD",
     ],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//:__subpackages__"],  # Needs skylib's root BUILD file for default_applicable_licenses
 )
 
 # The files needed for distribution


### PR DESCRIPTION
All other test_deps targets implicitly require the root BUILD file for the `license` target for their default_applicable_licenses; therefore, users should only depend on the root test_deps target.