### PR TITLE
Add MODULE.bazel.lock to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bazel-*
+MODULE.bazel.lock


### PR DESCRIPTION
I would add --lockfile_mode=off to .bazelrc, but this should support older versions of bazel before the lockfile_mode flag was released.