### PR TITLE
Add is_normalized and starts_with to paths module

### DIFF
--- a/docs/paths_doc.md
+++ b/docs/paths_doc.md
@@ -91,7 +91,7 @@ Returns `True` if `path` is an absolute path.
 paths.is_normalized(<a href="#paths.is_normalized-str">str</a>, <a href="#paths.is_normalized-look_for_same_level_references">look_for_same_level_references</a>)
 </pre>
 
-Returns true if the passed path contains uplevel references "..".
+Returns true if the passed path doesn't contain uplevel references "..".
 
 Also checks for single-dot references "." if look_for_same_level_references
 is `True.`
@@ -103,7 +103,7 @@ is `True.`
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="paths.is_normalized-str"></a>str |  The path string to check.   |  none |
-| <a id="paths.is_normalized-look_for_same_level_references"></a>look_for_same_level_references |  If True checks if path contains uplevel references ".." or single-dot references ".".   |  `True` |
+| <a id="paths.is_normalized-look_for_same_level_references"></a>look_for_same_level_references |  If True checks if path doesn't contain uplevel references ".." or single-dot references ".".   |  `True` |
 
 **RETURNS**
 

--- a/docs/paths_doc.md
+++ b/docs/paths_doc.md
@@ -83,6 +83,33 @@ Returns `True` if `path` is an absolute path.
 `True` if `path` is an absolute path.
 
 
+<a id="paths.is_normalized"></a>
+
+## paths.is_normalized
+
+<pre>
+paths.is_normalized(<a href="#paths.is_normalized-str">str</a>, <a href="#paths.is_normalized-look_for_same_level_references">look_for_same_level_references</a>)
+</pre>
+
+Returns true if the passed path contains uplevel references "..".
+
+Also checks for single-dot references "." if look_for_same_level_references
+is `True.`
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="paths.is_normalized-str"></a>str |  The path string to check.   |  none |
+| <a id="paths.is_normalized-look_for_same_level_references"></a>look_for_same_level_references |  If True checks if path contains uplevel references ".." or single-dot references ".".   |  `True` |
+
+**RETURNS**
+
+True if the path is normalized, False otherwise.
+
+
 <a id="paths.join"></a>
 
 ## paths.join
@@ -237,5 +264,26 @@ A tuple `(root, ext)` such that the root is the path without the file
 extension, and `ext` is the file extension (which, if non-empty, contains
 the leading dot). The returned tuple always satisfies the relationship
 `root + ext == p`.
+
+
+<a id="paths.starts_with"></a>
+
+## paths.starts_with
+
+<pre>
+paths.starts_with(<a href="#paths.starts_with-path_a">path_a</a>, <a href="#paths.starts_with-path_b">path_b</a>)
+</pre>
+
+Returns True if and only if path_b is an ancestor of path_a.
+
+Does not handle OS dependent case-insensitivity.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="paths.starts_with-path_a"></a>path_a |  <p align="center"> - </p>   |  none |
+| <a id="paths.starts_with-path_b"></a>path_b |  <p align="center"> - </p>   |  none |
 
 

--- a/lib/paths.bzl
+++ b/lib/paths.bzl
@@ -159,18 +159,18 @@ _DOT = 2
 _DOTDOT = 3
 
 def _is_normalized(str, look_for_same_level_references = True):
-    """Returns true if the passed path contains uplevel references "..".
+    """Returns true if the passed path doesn't contain uplevel references "..".
 
     Also checks for single-dot references "." if look_for_same_level_references
     is `True.`
 
     Args:
-        str: The path string to check.
-        look_for_same_level_references: If True checks if path contains uplevel
-          references ".." or single-dot references ".".
+      str: The path string to check.
+      look_for_same_level_references: If True checks if path doesn't contain
+        uplevel references ".." or single-dot references ".".
 
     Returns:
-        True if the path is normalized, False otherwise.
+      True if the path is normalized, False otherwise.
     """
     state = _SEPARATOR
     for c in str.elems():

--- a/lib/paths.bzl
+++ b/lib/paths.bzl
@@ -153,6 +153,67 @@ def _normalize(path):
 
     return path or "."
 
+_BASE = 0
+_SEPARATOR = 1
+_DOT = 2
+_DOTDOT = 3
+
+def _is_normalized(str, look_for_same_level_references = True):
+    """Returns true if the passed path contains uplevel references "..".
+
+    Also checks for single-dot references "." if look_for_same_level_references
+    is `True.`
+
+    Args:
+        str: The path string to check.
+        look_for_same_level_references: If True checks if path contains uplevel
+          references ".." or single-dot references ".".
+
+    Returns:
+        True if the path is normalized, False otherwise.
+    """
+    state = _SEPARATOR
+    for c in str.elems():
+        is_separator = False
+        if c == "/":
+            is_separator = True
+
+        if state == _BASE:
+            if is_separator:
+                state = _SEPARATOR
+            else:
+                state = _BASE
+        elif state == _SEPARATOR:
+            if is_separator:
+                state = _SEPARATOR
+            elif c == ".":
+                state = _DOT
+            else:
+                state = _BASE
+        elif state == _DOT:
+            if is_separator:
+                if look_for_same_level_references:
+                    # "." segment found.
+                    return False
+                state = _SEPARATOR
+            elif c == ".":
+                state = _DOTDOT
+            else:
+                state = _BASE
+        elif state == _DOTDOT:
+            if is_separator:
+                return False
+            else:
+                state = _BASE
+
+    if state == _DOT:
+        if look_for_same_level_references:
+            # "." segment found.
+            return False
+    elif state == _DOTDOT:
+        return False
+    return True
+
 def _relativize(path, start):
     """Returns the portion of `path` that is relative to `start`.
 
@@ -230,13 +291,30 @@ def _split_extension(p):
     dot_distance_from_end = len(b) - last_dot_in_basename
     return (p[:-dot_distance_from_end], p[-dot_distance_from_end:])
 
+def _starts_with(path_a, path_b):
+    """Returns True if and only if path_b is an ancestor of path_a.
+
+    Does not handle OS dependent case-insensitivity."""
+    if not path_b:
+        # all paths start with the empty string
+        return True
+    norm_a = _normalize(path_a)
+    norm_b = _normalize(path_b)
+    if len(norm_b) > len(norm_a):
+        return False
+    if not norm_a.startswith(norm_b):
+        return False
+    return len(norm_a) == len(norm_b) or norm_a[len(norm_b)] == "/"
+
 paths = struct(
     basename = _basename,
     dirname = _dirname,
     is_absolute = _is_absolute,
     join = _join,
     normalize = _normalize,
+    is_normalized = _is_normalized,
     relativize = _relativize,
     replace_extension = _replace_extension,
     split_extension = _split_extension,
+    starts_with = _starts_with,
 )


### PR DESCRIPTION

Those two functions are often used by built-in rules. This will make it easier to move them out of Bazel binary.