### PR TITLE
fix: Ensure directories work when the package is empty

### DIFF
--- a/rules/directory/directory.bzl
+++ b/rules/directory/directory.bzl
@@ -47,9 +47,10 @@ def _directory_impl(ctx):
     f = ctx.actions.declare_file("_directory_rule_" + ctx.label.name)
     ctx.actions.write(f, "")
 
-    source_prefix = ctx.label.package + "/"
+    source_prefix = ctx.label.package
     if ctx.label.workspace_root:
         source_prefix = ctx.label.workspace_root + "/" + source_prefix
+    source_prefix = source_prefix.rstrip("/") + "/"
 
     # Mapping of a prefix to an arbitrary (but deterministic) file matching that path.
     # The arbitrary file is used to present error messages if we have both generated files and source files.

--- a/tests/directory/external_directory_tests.bzl
+++ b/tests/directory/external_directory_tests.bzl
@@ -14,9 +14,20 @@
 
 """Generates tests for the directory rules from outside the repository."""
 
+_ROOT_BUILD_FILE_CONTENTS = """
+load("@bazel_skylib//rules/directory:directory.bzl", "directory")
+
+directory(
+    name = "root",
+    srcs = ["BUILD"],
+)
+"""
+
 def _external_directory_tests_impl(repo_ctx):
     for f in repo_ctx.attr.files:
         repo_ctx.symlink(repo_ctx.path(f), f.package + "/" + f.name)
+
+    repo_ctx.file("BUILD", _ROOT_BUILD_FILE_CONTENTS)
 
 # Directory paths work differently while inside and outside the repository.
 # To properly test this, we copy all our test code to an external


### PR DESCRIPTION
Previously, I was getting the error
`Expected external/_main~toolchains~toolchain_sdk/usr/bin/clang++ to start with one of ["external/_main~toolchains~toolchain_sdk//", "bazel-out/k8-dbg/bin/external/_main~toolchains~toolchain_sdk/"]`