### PR TITLE
fix: Fix a bug in globs when middle is non-empty, but right is empty.

### DIFF
--- a/rules/directory/private/glob.bzl
+++ b/rules/directory/private/glob.bzl
@@ -67,7 +67,7 @@ def directory_glob_chunk(directory, chunk):
         left, right = chunk.split("*")
     entries = []
     for name, entry in directory.entries.items():
-        if name.startswith(left) and name.endswith(right) and len(left) + len(right) <= len(name) and middle in name[len(left):-len(right)]:
+        if name.startswith(left) and name.endswith(right) and len(left) + len(right) <= len(name) and middle in name[len(left):len(name) - len(right)]:
             entries.append(entry)
     return entries
 

--- a/tests/directory/glob_test.bzl
+++ b/tests/directory/glob_test.bzl
@@ -113,6 +113,22 @@ def _glob_test_impl(env, targets):
         "abbbc",
         "ab.b.bc",
     ])
+    _expect_glob_chunk(
+        env,
+        _with_children(["a", "ab", "ba"]),
+        "a*",
+    ).contains_exactly([
+        "a",
+        "ab",
+    ])
+    _expect_glob_chunk(
+        env,
+        _with_children(["a", "ab", "a.b.", "ba."]),
+        "a*b*",
+    ).contains_exactly([
+        "ab",
+        "a.b.",
+    ])
 
     _expect_glob(env, root, ["testdata/f1"]).contains_exactly([f1])
     _expect_glob(env, root, ["testdata/subdir/f2"]).contains_exactly([f2])


### PR DESCRIPTION
For example, if you try to match `*a*" against "ab", then we check:
```
left = ""
middle = "a"
right = ""
middle in name[len(left):len(name)-len(right)]:
"a" in "ab"[len(""):len(name)-len("")]:
"a" in "ab"[0:-0]
"a" in "" => False
```

The problem here is that negative numbers in python index from the back, but -0 is not a negative number, so it always results in the empty string.