### PR TITLE
Strip compatible_with from bzl_library rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -60,6 +60,9 @@ bzl_library(
 bzl_library(
     name = "bzl_library",
     srcs = ["bzl_library.bzl"],
+    deps = [
+        "//rules/private:bzl_library",
+    ],
 )
 
 bzl_library(

--- a/bzl_library.bzl
+++ b/bzl_library.bzl
@@ -1,4 +1,4 @@
-# Copyright 2024 The Bazel Authors. All rights reserved.
+# Copyright 2017 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/bzl_library.bzl
+++ b/bzl_library.bzl
@@ -17,8 +17,8 @@
 # buildifier: disable=bzl-visibility
 load(
     "//rules/private:bzl_library.bzl",
-    _bzl_library = "bzl_library",
     _StarlarkLibraryInfo = "StarlarkLibraryInfo",
+    _bzl_library = "bzl_library",
 )
 
 StarlarkLibraryInfo = _StarlarkLibraryInfo
@@ -30,6 +30,7 @@ def bzl_library(name, **kwargs):
         name: name
         **kwargs: see the generated doc for rules/private/bzl_library.
     """
+
     # buildifier: disable=unused-variable
     _ = kwargs.pop("compatible_with", None)
     _ = kwargs.pop("exec_compatible_with", None)

--- a/bzl_library.bzl
+++ b/bzl_library.bzl
@@ -1,4 +1,4 @@
-# Copyright 2017 The Bazel Authors. All rights reserved.
+# Copyright 2024 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,94 +14,24 @@
 
 """Skylib module containing a library rule for aggregating rules files."""
 
-StarlarkLibraryInfo = provider(
-    "Information on contained Starlark rules.",
-    fields = {
-        "srcs": "Top level rules files.",
-        "transitive_srcs": "Transitive closure of rules files required for " +
-                           "interpretation of the srcs",
-    },
+load(
+    "//rules/private:bzl_library.bzl",
+    _bzl_library = "bzl_library",
+    _StarlarkLibraryInfo = "StarlarkLibraryInfo",
 )
 
-def _bzl_library_impl(ctx):
-    deps_files = [x.files for x in ctx.attr.deps]
-    all_files = depset(ctx.files.srcs, order = "postorder", transitive = deps_files)
-    if not ctx.files.srcs and not deps_files:
-        fail("bzl_library rule '%s' has no srcs or deps" % ctx.label)
+StarlarkLibraryInfo = _StarlarkLibraryInfo
 
-    return [
-        # All dependent files should be listed in both `files` and in `runfiles`;
-        # this ensures that a `bzl_library` can be referenced as `data` from
-        # a separate program, or from `tools` of a genrule().
-        DefaultInfo(
-            files = all_files,
-            runfiles = ctx.runfiles(transitive_files = all_files),
-        ),
-
-        # We also define our own provider struct, for aggregation and testing.
-        StarlarkLibraryInfo(
-            srcs = ctx.files.srcs,
-            transitive_srcs = all_files,
-        ),
-    ]
-
-bzl_library = rule(
-    implementation = _bzl_library_impl,
-    attrs = {
-        "srcs": attr.label_list(
-            allow_files = [".bzl", ".scl"],
-            doc = "List of `.bzl` and `.scl` files that are processed to create this target.",
-        ),
-        "deps": attr.label_list(
-            allow_files = [".bzl", ".scl"],
-            doc = """List of other `bzl_library` or `filegroup` targets that are required by the
-Starlark files listed in `srcs`.""",
-        ),
-    },
-    doc = """Creates a logical collection of Starlark .bzl and .scl files.
-
-Example:
-  Suppose your project has the following structure:
-
-  ```
-  [workspace]/
-      WORKSPACE
-      BUILD
-      checkstyle/
-          BUILD
-          checkstyle.bzl
-      lua/
-          BUILD
-          lua.bzl
-          luarocks.bzl
-  ```
-
-  In this case, you can have `bzl_library` targets in `checkstyle/BUILD` and
-  `lua/BUILD`:
-
-  `checkstyle/BUILD`:
-
-  ```python
-  load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-  bzl_library(
-      name = "checkstyle-rules",
-      srcs = ["checkstyle.bzl"],
-  )
-  ```
-
-  `lua/BUILD`:
-
-  ```python
-  load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-  bzl_library(
-      name = "lua-rules",
-      srcs = [
-          "lua.bzl",
-          "luarocks.bzl",
-      ],
-  )
-  ```
-""",
-)
+def bzl_library(name, **kwargs):
+    _ = kwargs.pop("compatible_with", None)
+    _ = kwargs.pop("exec_compatible_with", None)
+    _ = kwargs.pop("features", None)
+    _ = kwargs.pop("target_compatible_with", None)
+    _bzl_library(
+        name = name,
+        compatible_with = [],
+        exec_compatible_with = [],
+        features = [],
+        target_compatible_with = [],
+        **kwargs
+    )

--- a/bzl_library.bzl
+++ b/bzl_library.bzl
@@ -14,6 +14,7 @@
 
 """Skylib module containing a library rule for aggregating rules files."""
 
+# buildifier: disable=bzl-visibility
 load(
     "//rules/private:bzl_library.bzl",
     _bzl_library = "bzl_library",
@@ -23,6 +24,13 @@ load(
 StarlarkLibraryInfo = _StarlarkLibraryInfo
 
 def bzl_library(name, **kwargs):
+    """Wrapper for bzl_library.
+
+    Args:
+        name: name
+        **kwargs: see the generated doc for rules/private/bzl_library.
+    """
+    # buildifier: disable=unused-variable
     _ = kwargs.pop("compatible_with", None)
     _ = kwargs.pop("exec_compatible_with", None)
     _ = kwargs.pop("features", None)

--- a/docs/BUILD
+++ b/docs/BUILD
@@ -18,7 +18,7 @@ stardoc_with_diff_test(
 
 stardoc_with_diff_test(
     name = "bzl_library",
-    bzl_library_target = "//:bzl_library",
+    bzl_library_target = "//rules/private:bzl_library",
     out_label = "//docs:bzl_library.md",
 )
 

--- a/rules/private/BUILD
+++ b/rules/private/BUILD
@@ -8,12 +8,15 @@ bzl_library(
     name = "bzl_library",
     srcs = ["bzl_library.bzl"],
     visibility = [
-        "//docs:__pkg__",
         "//:__pkg__",
+        "//docs:__pkg__",
     ],
 )
 
-exports_files(["bzl_library.bzl"], visibility=["//docs:__pkg__"])
+exports_files(
+    ["bzl_library.bzl"],
+    visibility = ["//docs:__pkg__"],
+)
 
 bzl_library(
     name = "copy_common",

--- a/rules/private/BUILD
+++ b/rules/private/BUILD
@@ -5,6 +5,17 @@ package(default_applicable_licenses = ["//:license"])
 licenses(["notice"])
 
 bzl_library(
+    name = "bzl_library",
+    srcs = ["bzl_library.bzl"],
+    visibility = [
+        "//docs:__pkg__",
+        "//:__pkg__",
+    ],
+)
+
+exports_files(["bzl_library.bzl"], visibility=["//docs:__pkg__"])
+
+bzl_library(
     name = "copy_common",
     srcs = ["copy_common.bzl"],
     visibility = ["//rules:__pkg__"],

--- a/rules/private/bzl_library.bzl
+++ b/rules/private/bzl_library.bzl
@@ -1,0 +1,107 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylib module containing a library rule for aggregating rules files."""
+
+StarlarkLibraryInfo = provider(
+    "Information on contained Starlark rules.",
+    fields = {
+        "srcs": "Top level rules files.",
+        "transitive_srcs": "Transitive closure of rules files required for " +
+                           "interpretation of the srcs",
+    },
+)
+
+def _bzl_library_impl(ctx):
+    deps_files = [x.files for x in ctx.attr.deps]
+    all_files = depset(ctx.files.srcs, order = "postorder", transitive = deps_files)
+    if not ctx.files.srcs and not deps_files:
+        fail("bzl_library rule '%s' has no srcs or deps" % ctx.label)
+
+    return [
+        # All dependent files should be listed in both `files` and in `runfiles`;
+        # this ensures that a `bzl_library` can be referenced as `data` from
+        # a separate program, or from `tools` of a genrule().
+        DefaultInfo(
+            files = all_files,
+            runfiles = ctx.runfiles(transitive_files = all_files),
+        ),
+
+        # We also define our own provider struct, for aggregation and testing.
+        StarlarkLibraryInfo(
+            srcs = ctx.files.srcs,
+            transitive_srcs = all_files,
+        ),
+    ]
+
+bzl_library = rule(
+    implementation = _bzl_library_impl,
+    attrs = {
+        "srcs": attr.label_list(
+            allow_files = [".bzl", ".scl"],
+            doc = "List of `.bzl` and `.scl` files that are processed to create this target.",
+        ),
+        "deps": attr.label_list(
+            allow_files = [".bzl", ".scl"],
+            doc = """List of other `bzl_library` or `filegroup` targets that are required by the
+Starlark files listed in `srcs`.""",
+        ),
+    },
+    doc = """Creates a logical collection of Starlark .bzl and .scl files.
+
+Example:
+  Suppose your project has the following structure:
+
+  ```
+  [workspace]/
+      WORKSPACE
+      BUILD
+      checkstyle/
+          BUILD
+          checkstyle.bzl
+      lua/
+          BUILD
+          lua.bzl
+          luarocks.bzl
+  ```
+
+  In this case, you can have `bzl_library` targets in `checkstyle/BUILD` and
+  `lua/BUILD`:
+
+  `checkstyle/BUILD`:
+
+  ```python
+  load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+  bzl_library(
+      name = "checkstyle-rules",
+      srcs = ["checkstyle.bzl"],
+  )
+  ```
+
+  `lua/BUILD`:
+
+  ```python
+  load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+  bzl_library(
+      name = "lua-rules",
+      srcs = [
+          "lua.bzl",
+          "luarocks.bzl",
+      ],
+  )
+  ```
+""",
+)


### PR DESCRIPTION
Wrap bzl_library in a macro so that we can force off some global attributes that are never appropriate for analysis of build rules.

The motivation is that when people use `package(default_compatible_with=X)` alongside `bzl_library`, they have accidentally marked their _build rules_ as eligible to deliver to some target environment. This can cause `...` scoped tests on cross platform projects to fail because the user defined rules are not the code we are shipping.

An alternative idea was to use a rule initializer for this. That is the better solution, but it would require a newer version of Bazel, so I opted for the backwards compatible solution.