### PR TITLE
feat: case insensitive diff_test

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -108,7 +108,6 @@ tasks:
       # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
       # https://github.com/bazelbuild/bazel/issues/7761 is fixed
       ? "--test_env=LOCALAPPDATA"
-      ? "--test_tag_filters=-no_windows"
 
   last_green:
     <<: *reusable_config
@@ -126,6 +125,5 @@ tasks:
       # TODO(laszlocsomor): remove "--test_env=LOCALAPPDATA" after
       # https://github.com/bazelbuild/bazel/issues/7761 is fixed
       ? "--test_env=LOCALAPPDATA"
-      ? "--test_tag_filters=-no_windows"
 
 buildifier: latest

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+# symlinks required on windows by copy_directory
+startup --windows_enable_symlinks

--- a/docs/diff_test_doc.md
+++ b/docs/diff_test_doc.md
@@ -10,7 +10,7 @@ command (fc.exe) on Windows (no Bash is required).
 ## diff_test
 
 <pre>
-diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-failure_message">failure_message</a>, <a href="#diff_test-kwargs">kwargs</a>)
+diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-failure_message">failure_message</a>, <a href="#diff_test-file1_to_lf">file1_to_lf</a>, <a href="#diff_test-file2_to_lf">file2_to_lf</a>, <a href="#diff_test-kwargs">kwargs</a>)
 </pre>
 
 A test that compares two files.
@@ -27,6 +27,8 @@ The test succeeds if the files' contents match.
 | <a id="diff_test-file1"></a>file1 |  Label of the file to compare to `file2`.   |  none |
 | <a id="diff_test-file2"></a>file2 |  Label of the file to compare to `file1`.   |  none |
 | <a id="diff_test-failure_message"></a>failure_message |  Additional message to log if the files' contents do not match.   |  `None` |
+| <a id="diff_test-file1_to_lf"></a>file1_to_lf |  Convert file1 to LF line endings before comparison.   |  `None` |
+| <a id="diff_test-file2_to_lf"></a>file2_to_lf |  Convert file2 to LF line endings before comparison.   |  `None` |
 | <a id="diff_test-kwargs"></a>kwargs |  The [common attributes for tests](https://bazel.build/reference/be/common-definitions#common-attributes-tests).   |  none |
 
 

--- a/docs/diff_test_doc.md
+++ b/docs/diff_test_doc.md
@@ -10,7 +10,7 @@ command (fc.exe) on Windows (no Bash is required).
 ## diff_test
 
 <pre>
-diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-failure_message">failure_message</a>, <a href="#diff_test-file1_to_lf">file1_to_lf</a>, <a href="#diff_test-file2_to_lf">file2_to_lf</a>, <a href="#diff_test-kwargs">kwargs</a>)
+diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-failure_message">failure_message</a>, <a href="#diff_test-ignore_line_endings">ignore_line_endings</a>, <a href="#diff_test-kwargs">kwargs</a>)
 </pre>
 
 A test that compares two files.
@@ -27,8 +27,7 @@ The test succeeds if the files' contents match.
 | <a id="diff_test-file1"></a>file1 |  Label of the file to compare to `file2`.   |  none |
 | <a id="diff_test-file2"></a>file2 |  Label of the file to compare to `file1`.   |  none |
 | <a id="diff_test-failure_message"></a>failure_message |  Additional message to log if the files' contents do not match.   |  `None` |
-| <a id="diff_test-file1_to_lf"></a>file1_to_lf |  Convert file1 to LF line endings before comparison.   |  `None` |
-| <a id="diff_test-file2_to_lf"></a>file2_to_lf |  Convert file2 to LF line endings before comparison.   |  `None` |
+| <a id="diff_test-ignore_line_endings"></a>ignore_line_endings |  Ignore differences between CRLF and LF line endings. On windows, this is forced to False if the 'tr' command can't be found in the bash installation on the host.   |  `True` |
 | <a id="diff_test-kwargs"></a>kwargs |  The [common attributes for tests](https://bazel.build/reference/be/common-definitions#common-attributes-tests).   |  none |
 
 

--- a/docs/private/stardoc_with_diff_test.bzl
+++ b/docs/private/stardoc_with_diff_test.bzl
@@ -58,6 +58,8 @@ def stardoc_with_diff_test(
         file1 = out_label,
         # Output from stardoc rule above
         file2 = out_file.replace(".md", "-docgen.md"),
+        # Stardoc generates CRLF line endings on windows. file1 has LF endings.
+        file2_to_lf = True,
         tags = ["no_windows"],
     )
 

--- a/docs/private/stardoc_with_diff_test.bzl
+++ b/docs/private/stardoc_with_diff_test.bzl
@@ -58,9 +58,6 @@ def stardoc_with_diff_test(
         file1 = out_label,
         # Output from stardoc rule above
         file2 = out_file.replace(".md", "-docgen.md"),
-        # Stardoc generates CRLF line endings on windows. file1 has LF endings.
-        file2_to_lf = True,
-        tags = ["no_windows"],
     )
 
 def update_docs(

--- a/rules/diff_test.bzl
+++ b/rules/diff_test.bzl
@@ -26,6 +26,12 @@ def _runfiles_path(f):
     else:
         return f.path  # source file
 
+def _ignore_line_endings(ctx):
+    ignore_line_endings = "0"
+    if ctx.attr.ignore_line_endings:
+        ignore_line_endings = "1"
+    return ignore_line_endings
+
 def _diff_test_impl(ctx):
     if ctx.attr.is_windows:
         bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path
@@ -52,6 +58,7 @@ if not exist %MF% (
     echo Manifest file %MF% not found
     exit /b 1
 )
+echo using %MF%
 set F1={file1}
 set F2={file2}
 if "!F1:~0,9!" equ "external/" (set F1=!F1:~9!) else (set F1=!TEST_WORKSPACE!/!F1!)
@@ -94,30 +101,36 @@ if "!RF2!" equ "" (
     exit /b 1
   )
 )
-rem use tr command from msys64 package, msys64 is a bazel prerequisite
-rem todo: in future better to pull in a binary to do this
-if "{f1_to_lf}"=="1" (
-  for %%f in (!RF1!) do set RF_TEMP=%TEST_TMPDIR%\\%%~nxf_lf
-  for %%f in ({bash_bin}) do set "TR=%%~dpf\\tr"
-  echo type "!RF1!" ^| !TR! -d "\\r"
-  type "!RF1!" | !TR! -d "\\r" > "!RF_TEMP!"
-  rem echo original file !RF1! replaced by !RF_TEMP!
-  set "RF1=!RF_TEMP!"
+rem use tr command from msys64 package, msys64 is a bazel recommendation
+rem todo: in future better to pull in diff.exe to align with non-windows path
+if "{ignore_line_endings}"=="1" (
+  if exist {bash_bin} (
+    for %%f in ({bash_bin}) do set "TR=%%~dpf\\tr.exe"
+  ) else (
+    rem match bazel's algorithm to find unix tools
+    set "TR=C:\\msys64\\usr\\bin\\tr.exe"
+  )
+  if not exist !TR! (
+    echo>&2 WARNING: ignore_line_endings set but !TR! not found; line endings will be compared
+  ) else (
+    for %%f in (!RF1!) do set RF1_TEMP=%TEST_TMPDIR%\\%%~nxf_lf1
+    for %%f in (!RF2!) do set RF2_TEMP=%TEST_TMPDIR%\\%%~nxf_lf2
+    type "!RF1!" | !TR! -d "\\r" > "!RF1_TEMP!"
+    type "!RF2!" | !TR! -d "\\r" > "!RF2_TEMP!"
+    set "RF1=!RF1_TEMP!"
+    set "RF2=!RF2_TEMP!"
+    rem echo original file !RF1! replaced by !RF1_TEMP!
+    rem echo original file !RF2! replaced by !RF2_TEMP!
+  )
 )
-if "{f2_to_lf}"=="1" (
-  for %%f in (!RF2!) do set RF_TEMP=%TEST_TMPDIR%\\%%~nxf_lf
-  for %%f in ({bash_bin}) do set "TR=%%~dpf\\tr"
-  echo type "!RF2!" ^| !TR! -d "\\r"
-  type "!RF2!" | !TR! -d "\\r" > "!RF_TEMP!"
-  rem echo original file !RF2! replaced by !RF_TEMP!
-  set "RF2=!RF_TEMP!"
-)
-rem echo fc.exe /B "!RF1!" "!RF2!"
 fc.exe 2>NUL 1>NUL /B "!RF1!" "!RF2!"
 if %ERRORLEVEL% neq 0 (
   if %ERRORLEVEL% equ 1 (
-    echo>&2 FAIL: files "{file1}" and "{file2}" differ. {fail_msg}
-    echo why? diff "!RF1!" "!RF2!" ^| cat -v
+    set "FAIL_MSG={fail_msg}"
+    if "!FAIL_MSG!"=="" (
+        set "FAIL_MSG=why? diff ^"!RF1!^" ^"!RF2!^" ^| cat -v"
+    )
+    echo>&2 FAIL: files "{file1}" and "{file2}" differ. !FAIL_MSG!
     exit /b 1
   ) else (
     fc.exe /B "!RF1!" "!RF2!"
@@ -129,8 +142,7 @@ if %ERRORLEVEL% neq 0 (
                 fail_msg = ctx.attr.failure_message,
                 file1 = _runfiles_path(ctx.file.file1),
                 file2 = _runfiles_path(ctx.file.file2),
-                f1_to_lf = "1" if ctx.attr.file1_to_lf else "0",
-                f2_to_lf = "1" if ctx.attr.file2_to_lf else "0",
+                ignore_line_endings = _ignore_line_endings(ctx),
                 bash_bin = bash_bin
             ),
             is_executable = True,
@@ -158,14 +170,19 @@ else
   echo >&2 "ERROR: could not find \"{file1}\" and \"{file2}\""
   exit 1
 fi
-if ! diff "$RF1" "$RF2"; then
-  echo >&2 "FAIL: files \"{file1}\" and \"{file2}\" differ. "{fail_msg}
+if ! diff {strip_trailing_cr}"$RF1" "$RF2"; then
+  MSG={fail_msg}
+  if [[ "${{MSG}}"=="" (
+      MSG="why? diff {strip_trailing_cr}"${RF1}" "${RF2}" | cat -v"
+  )
+  echo >&2 "FAIL: files \"{file1}\" and \"{file2}\" differ. ${MSG}"
   exit 1
 fi
 """.format(
                 fail_msg = shell.quote(ctx.attr.failure_message),
                 file1 = _runfiles_path(ctx.file.file1),
                 file2 = _runfiles_path(ctx.file.file2),
+                strip_trailing_cr = "--strip-trailing-cr " if ctx.attr.ignore_line_endings else ""
             ),
             is_executable = True,
         )
@@ -186,11 +203,8 @@ _diff_test = rule(
             allow_single_file = True,
             mandatory = True,
         ),
-        "file1_to_lf": attr.bool(
-            default = False,
-        ),
-        "file2_to_lf": attr.bool(
-            default = False,
+        "ignore_line_endings": attr.bool(
+            default = True,
         ),
         "is_windows": attr.bool(mandatory = True),
     },
@@ -201,7 +215,7 @@ _diff_test = rule(
     implementation = _diff_test_impl,
 )
 
-def diff_test(name, file1, file2, failure_message = None, file1_to_lf = None, file2_to_lf = None, **kwargs):
+def diff_test(name, file1, file2, failure_message = None, ignore_line_endings = True, **kwargs):
     """A test that compares two files.
 
     The test succeeds if the files' contents match.
@@ -210,8 +224,8 @@ def diff_test(name, file1, file2, failure_message = None, file1_to_lf = None, fi
       name: The name of the test rule.
       file1: Label of the file to compare to `file2`.
       file2: Label of the file to compare to `file1`.
-      file1_to_lf: Convert file1 to LF line endings before comparison.
-      file2_to_lf: Convert file2 to LF line endings before comparison.
+      ignore_line_endings: Ignore differences between CRLF and LF line endings. On windows, this is 
+          forced to False if the 'tr' command can't be found in the bash installation on the host.
       failure_message: Additional message to log if the files' contents do not match.
       **kwargs: The [common attributes for tests](https://bazel.build/reference/be/common-definitions#common-attributes-tests).
     """
@@ -219,8 +233,7 @@ def diff_test(name, file1, file2, failure_message = None, file1_to_lf = None, fi
         name = name,
         file1 = file1,
         file2 = file2,
-        file1_to_lf = file1_to_lf,
-        file2_to_lf = file2_to_lf,
+        ignore_line_endings = ignore_line_endings,
         failure_message = failure_message,
         is_windows = select({
             "@bazel_tools//src/conditions:host_windows": True,

--- a/rules/private/copy_directory_private.bzl
+++ b/rules/private/copy_directory_private.bzl
@@ -34,9 +34,9 @@ def _copy_cmd(ctx, src, dst):
     # https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/robocopy
     # NB: robocopy return non-zero exit codes on success so we must exit 0 after calling it
     cmd_tmpl = """\
-if not exist \"{src}\\\" (
-  echo Error: \"{src}\" is not a directory
-  @exit 1
+@if not exist \"{src}\\*\" (
+@  echo Error: \"{src}\" is not a directory
+@  exit 1
 )
 @robocopy \"{src}\" \"{dst}\" /E /MIR >NUL & @exit 0
 """

--- a/tests/diff_test/diff_test_tests.sh
+++ b/tests/diff_test/diff_test_tests.sh
@@ -80,12 +80,13 @@ eof
   echo bar > "$ws/$subdir/b.txt"
 
   (cd "$ws" && \
-   bazel test ${flags} "//${subdir%/}:same" --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} "//${subdir%/}:same" --test_output=errors --noshow_progress 1>>"$TEST_log" 2>&1 \
      || fail "expected success")
 
   (cd "$ws" && \
-   bazel test ${flags} "//${subdir%/}:different" --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} "//${subdir%/}:different" --test_output=all --noshow_progress 1>>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
+
   expect_log "FAIL: files \"${subdir}a.txt\" and \"${subdir}b.txt\" differ"
 }
 
@@ -175,21 +176,21 @@ diff_test(
 eof
 
   (cd "$ws/main" && \
-   bazel test ${flags} //:same --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} //:same --test_output=errors --noshow_progress 1>"$TEST_log" 2>&1 \
      || fail "expected success")
 
   (cd "$ws/main" && \
-   bazel test ${flags} //:different1 --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} //:different1 --test_output=all --noshow_progress 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
   expect_log 'FAIL: files "external/ext1/foo/foo.txt" and "external/ext2/foo/bar.txt" differ'
 
   (cd "$ws/main" && \
-   bazel test ${flags} //:different2 --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} //:different2 --test_output=all --noshow_progress 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
   expect_log 'FAIL: files "external/ext1/foo/foo.txt" and "ext1/foo/foo.txt" differ'
 
   (cd "$ws/main" && \
-   bazel test ${flags} //:different3 --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test ${flags} //:different3 --test_output=all --noshow_progress 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
   expect_log 'FAIL: files "ext2/foo/foo.txt" and "external/ext2/foo/foo.txt" differ'
 }
@@ -257,15 +258,15 @@ eof
   echo bar > "$ws/d.txt"
 
   (cd "$ws" && \
-   bazel test //:different_with_message --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test //:different_with_message --test_output=errors --noshow_progress 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
   # TODO(arostovtsev): also test Windows cmd.exe escapes when https://github.com/bazelbuild/bazel-skylib/pull/363 is merged
   expect_log "FAIL: files \"a.txt\" and \"b.txt\" differ. This is an \`\$error\`"
 
   (cd "$ws" && \
-   bazel test //:different_without_message --test_output=errors 1>"$TEST_log" 2>&1 \
+   bazel test //:different_without_message --test_output=all --noshow_progress 1>"$TEST_log" 2>&1 \
      && fail "expected failure" || true)
-  expect_log "FAIL: files \"c.txt\" and \"d.txt\" differ. $"
+  expect_log "FAIL: files \"c.txt\" and \"d.txt\" differ. why? diff"
 }
 
 cd "$TEST_TMPDIR"


### PR DESCRIPTION
In my work on windows quality in rulesets, a frequent issue I am finding is that diff_tests are failing due to differences in line endings -- either due to differences in the 'expected' values, or cross-platform differences in generators (e.g. buildifier always writes LF, whilst skydoc writes LF or CRLF depending on platform).

We can't expect rule authors to work around these differences, because in practice they do not have good access to windows dev hardware.

The goal of this PR is to make diff_test slightly less brittle and ignore line endings by default. An `ignore_line_endings` flag is provided to switch this behavior.

This flag is supported by the `diff` command on unix. On windows, it requires the `tr.exe` command that is part of most bash installs including msys2. If `tr.exe` cannot be found the `ignore_line_endings` flag is silently ignored and set to False.

This PR allows us to enable the 1 disabled test 'stardoc_with_diff_test' on windows CI, and also fixes many test failures in dependent rulesets such as rules_starlib and rules_bazel_integration_test
