### PR TITLE
bzl gazelle support overwrite resolve

### DIFF
--- a/gazelle/bzl/gazelle.go
+++ b/gazelle/bzl/gazelle.go
@@ -152,6 +152,13 @@ func (*bzlLibraryLang) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo
 
 	deps := make([]string, 0, len(imports))
 	for _, imp := range imports {
+
+		if l, ok := resolve.FindRuleWithOverride(c, resolve.ImportSpec{Lang: languageName, Imp: imp}, languageName); ok {
+			depLabel := l.Rel(from.Repo, from.Pkg)
+			deps = append(deps, depLabel.String())
+			continue
+		}
+
 		impLabel, err := label.Parse(imp)
 		if err != nil {
 			log.Printf("%s: import of %q is invalid: %v", from.String(), imp, err)

--- a/gazelle/bzl/testdata/resolve_overwrite/BUILD.in
+++ b/gazelle/bzl/testdata/resolve_overwrite/BUILD.in
@@ -1,0 +1,8 @@
+# Some comment to be preserved
+
+# gazelle:resolve starlark starlark //internal:defs.bzl //internal:defs_bzl
+
+filegroup(
+    name = "allfiles",
+    srcs = glob(["**"]),
+)

--- a/gazelle/bzl/testdata/resolve_overwrite/BUILD.out
+++ b/gazelle/bzl/testdata/resolve_overwrite/BUILD.out
@@ -1,0 +1,17 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+# Some comment to be preserved
+
+# gazelle:resolve starlark starlark //internal:defs.bzl //internal:defs_bzl
+
+filegroup(
+    name = "allfiles",
+    srcs = glob(["**"]),
+)
+
+bzl_library(
+    name = "foo",
+    srcs = ["foo.bzl"],
+    visibility = ["//visibility:public"],
+    deps = ["//internal:defs_bzl"],
+)

--- a/gazelle/bzl/testdata/resolve_overwrite/foo.bzl
+++ b/gazelle/bzl/testdata/resolve_overwrite/foo.bzl
@@ -1,0 +1,7 @@
+"""
+Doc string
+"""
+
+load("//internal:defs.bzl", "deps")
+
+deps()

--- a/gazelle/bzl/testdata/resolve_overwrite/internal/BUILD
+++ b/gazelle/bzl/testdata/resolve_overwrite/internal/BUILD
@@ -1,0 +1,7 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "deps_bzl",
+    srcs = ["deps.bzl"],
+    visibility = ["//:__subpackages__"],
+)

--- a/gazelle/bzl/testdata/resolve_overwrite/internal/defs.bzl
+++ b/gazelle/bzl/testdata/resolve_overwrite/internal/defs.bzl
@@ -1,0 +1,6 @@
+"""
+Simple deps
+"""
+
+def deps():
+    pass


### PR DESCRIPTION
Support using `gazelle:resolve` [directives](https://github.com/bazelbuild/bazel-gazelle?tab=readme-ov-file#directives) to overwrite dependencies resolve. 
Especially for some non-standard bzl naming, such as:
```
# gazelle:resolve starlark starlark @io_bazel_rules_docker//docker/util:run.bzl @io_bazel_rules_docker//docker/util
# gazelle:resolve starlark starlark @io_bazel_rules_docker//repositories:deps.bzl @io_bazel_rules_docker//repositories
# gazelle:resolve starlark starlark @io_bazel_rules_docker//repositories:repositories.bzl @io_bazel_rules_docker//repositories
# gazelle:resolve starlark starlark @rules_python//python:defs.bzl @rules_python//python:defs_bzl
# gazelle:resolve starlark starlark @npm//:vite/package_json.bzl @npm//:vite_bzl_library
# gazelle:resolve starlark starlark @npm//:docsify-cli/package_json.bzl @npm//:docsify-cli_bzl_library
# gazelle:resolve starlark starlark @npm//:typedoc/package_json.bzl @npm//:typedoc_bzl_library
# gazelle:resolve starlark starlark @npm//:api-spec-converter/package_json.bzl @npm//:api-spec-converter_bzl_library
# gazelle:resolve starlark starlark @rules_nodejs//nodejs:repositories.bzl @rules_nodejs//nodejs:bzl

```


