### PR TITLE
Add apparent_repo_name utility to modules.bzl

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,3 +37,6 @@ use_repo(as_extension_test_ext, "bar", "foo")
 
 use_all_repos_test_ext = use_extension("//tests:modules_test.bzl", "use_all_repos_test_ext", dev_dependency = True)
 use_repo(use_all_repos_test_ext, "baz", "qux")
+
+apparent_repo_name_test_ext = use_extension("//tests:extensions/apparent_repo_name.bzl", "apparent_repo_name_test_ext", dev_dependency = True)
+use_repo(apparent_repo_name_test_ext, "apparent-repo-name-test")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,3 +81,7 @@ load("//tests/directory:external_directory_tests.bzl", "external_directory_tests
 external_directory_tests(name = "external_directory_tests")
 
 register_unittest_toolchains()
+
+load("//tests:extensions/apparent_repo_name.bzl", "apparent_repo_name_test_macro")
+
+apparent_repo_name_test_macro()

--- a/docs/modules_doc.md
+++ b/docs/modules_doc.md
@@ -2,29 +2,6 @@
 
 Skylib module containing utilities for Bazel modules and module extensions.
 
-<a id="modules.apparent_repo_label_string"></a>
-
-## modules.apparent_repo_label_string
-
-<pre>
-modules.apparent_repo_label_string(<a href="#modules.apparent_repo_label_string-label">label</a>)
-</pre>
-
-Return a Label string starting with its apparent repo name.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="modules.apparent_repo_label_string-label"></a>label |  a Label instance   |  none |
-
-**RETURNS**
-
-str(label) with its canonical repository name replaced with its apparent
-      repository name
-
-
 <a id="modules.apparent_repo_name"></a>
 
 ## modules.apparent_repo_name

--- a/docs/modules_doc.md
+++ b/docs/modules_doc.md
@@ -7,21 +7,41 @@ Skylib module containing utilities for Bazel modules and module extensions.
 ## modules.apparent_repo_name
 
 <pre>
-modules.apparent_repo_name(<a href="#modules.apparent_repo_name-label_or_name">label_or_name</a>)
+modules.apparent_repo_name(<a href="#modules.apparent_repo_name-repository_ctx">repository_ctx</a>)
 </pre>
 
-Return a repository's apparent repository name.
+Generates a repository's apparent name from a repository_ctx object.
+
+Useful when generating the default top level `BUILD` target for the
+repository.
+
+Example:
+```starlark
+_ALIAS_TARGET_TEMPLATE = """alias(
+    name = "{name}",
+    actual = "@{target_repo_name}",
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _alias_repository_impl(repository_ctx):
+    repository_ctx.file("BUILD", _ALIAS_TARGET_TEMPLATE.format(
+        name = apparent_repo_name(rctx),
+        target = rctx.attr.target_repo_name,
+    ))
+```
+
 
 **PARAMETERS**
 
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
-| <a id="modules.apparent_repo_name-label_or_name"></a>label_or_name |  a Label or repository name string   |  none |
+| <a id="modules.apparent_repo_name-repository_ctx"></a>repository_ctx |  a repository_ctx object   |  none |
 
 **RETURNS**
 
-The apparent repository name
+An apparent repo name derived from repository_ctx.name
 
 
 <a id="modules.as_extension"></a>

--- a/docs/modules_doc.md
+++ b/docs/modules_doc.md
@@ -2,6 +2,80 @@
 
 Skylib module containing utilities for Bazel modules and module extensions.
 
+<a id="modules.adjust_main_repo_prefix"></a>
+
+## modules.adjust_main_repo_prefix
+
+<pre>
+modules.adjust_main_repo_prefix(<a href="#modules.adjust_main_repo_prefix-target_pattern">target_pattern</a>)
+</pre>
+
+Updates the main repo prefix to match the current Bazel version.
+
+Used to automatically update strings representing include/exclude target
+patterns so that they match actual main repo target Labels correctly. The
+main repo prefix will be "@//" for Bazel < 7.1.0, and "@@//" for Bazel >=
+7.1.0 under Bzlmod.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="modules.adjust_main_repo_prefix-target_pattern"></a>target_pattern |  a string used to match a BUILD target pattern   |  none |
+
+**RETURNS**
+
+the string with any main repository prefix updated to match the current
+      Bazel version
+
+
+<a id="modules.apparent_repo_label_string"></a>
+
+## modules.apparent_repo_label_string
+
+<pre>
+modules.apparent_repo_label_string(<a href="#modules.apparent_repo_label_string-label">label</a>)
+</pre>
+
+Return a Label string starting with its apparent repo name.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="modules.apparent_repo_label_string-label"></a>label |  a Label instance   |  none |
+
+**RETURNS**
+
+str(label) with its canonical repository name replaced with its apparent
+      repository name
+
+
+<a id="modules.apparent_repo_name"></a>
+
+## modules.apparent_repo_name
+
+<pre>
+modules.apparent_repo_name(<a href="#modules.apparent_repo_name-label_or_name">label_or_name</a>)
+</pre>
+
+Return a repository's apparent repository name.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="modules.apparent_repo_name-label_or_name"></a>label_or_name |  a Label or repository name string   |  none |
+
+**RETURNS**
+
+The apparent repository name
+
+
 <a id="modules.as_extension"></a>
 
 ## modules.as_extension

--- a/docs/modules_doc.md
+++ b/docs/modules_doc.md
@@ -112,6 +112,33 @@ imported via `use_repo`. The extension is marked as reproducible if supported by
 version of Bazel and thus doesn't result in a lockfile entry.
 
 
+<a id="modules.repo_name"></a>
+
+## modules.repo_name
+
+<pre>
+modules.repo_name(<a href="#modules.repo_name-label_or_name">label_or_name</a>)
+</pre>
+
+Utility to provide Label compatibility with Bazel 5.
+
+Under Bazel 5, calls `Label.workspace_name`. Otherwise calls
+`Label.repo_name`.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="modules.repo_name-label_or_name"></a>label_or_name |  a Label or repository name string   |  none |
+
+**RETURNS**
+
+The repository name returned directly from the Label API, or the
+      original string if not a Label
+
+
 <a id="modules.use_all_repos"></a>
 
 ## modules.use_all_repos

--- a/docs/modules_doc.md
+++ b/docs/modules_doc.md
@@ -10,12 +10,12 @@ Skylib module containing utilities for Bazel modules and module extensions.
 modules.adjust_main_repo_prefix(<a href="#modules.adjust_main_repo_prefix-target_pattern">target_pattern</a>)
 </pre>
 
-Updates the main repo prefix to match the current Bazel version.
+Updates the main repository prefix to match the current Bazel version.
 
-Used to automatically update strings representing include/exclude target
-patterns so that they match actual main repo target Labels correctly. The
-main repo prefix will be "@//" for Bazel < 7.1.0, and "@@//" for Bazel >=
-7.1.0 under Bzlmod.
+The main repo prefix will be "@//" for Bazel < 7.1.0, and "@@//" for Bazel
+>= 7.1.0 under Bzlmod. This macro automatically updates strings representing
+include/exclude target patterns so that they match actual main repository
+target Labels correctly.
 
 
 **PARAMETERS**

--- a/docs/modules_doc.md
+++ b/docs/modules_doc.md
@@ -2,35 +2,6 @@
 
 Skylib module containing utilities for Bazel modules and module extensions.
 
-<a id="modules.adjust_main_repo_prefix"></a>
-
-## modules.adjust_main_repo_prefix
-
-<pre>
-modules.adjust_main_repo_prefix(<a href="#modules.adjust_main_repo_prefix-target_pattern">target_pattern</a>)
-</pre>
-
-Updates the main repository prefix to match the current Bazel version.
-
-The main repo prefix will be "@//" for Bazel < 7.1.0, and "@@//" for Bazel
->= 7.1.0 under Bzlmod. This macro automatically updates strings representing
-include/exclude target patterns so that they match actual main repository
-target Labels correctly.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="modules.adjust_main_repo_prefix-target_pattern"></a>target_pattern |  a string used to match a BUILD target pattern   |  none |
-
-**RETURNS**
-
-the string with any main repository prefix updated to match the current
-      Bazel version
-
-
 <a id="modules.apparent_repo_label_string"></a>
 
 ## modules.apparent_repo_label_string
@@ -110,33 +81,6 @@ A module extension that generates the repositories instantiated by the given mac
 uses [`use_all_repos`](#use_all_repos) to indicate that all of those repositories should be
 imported via `use_repo`. The extension is marked as reproducible if supported by the current
 version of Bazel and thus doesn't result in a lockfile entry.
-
-
-<a id="modules.repo_name"></a>
-
-## modules.repo_name
-
-<pre>
-modules.repo_name(<a href="#modules.repo_name-label_or_name">label_or_name</a>)
-</pre>
-
-Utility to provide Label compatibility with Bazel 5.
-
-Under Bazel 5, calls `Label.workspace_name`. Otherwise calls
-`Label.repo_name`.
-
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="modules.repo_name-label_or_name"></a>label_or_name |  a Label or repository name string   |  none |
-
-**RETURNS**
-
-The repository name returned directly from the Label API, or the
-      original string if not a Label
 
 
 <a id="modules.use_all_repos"></a>

--- a/lib/modules.bzl
+++ b/lib/modules.bzl
@@ -178,7 +178,9 @@ def _apparent_repo_label_string(label):
     label_str = "@" + str(label).lstrip("@")
     return label_str.replace(repo_name, _apparent_repo_name(label))
 
-_main_repo_prefix = str(Label("//:all")).split(":")[0]
+_is_bzlmod_enabled = str(Label("//:all")).startswith("@@")
+
+_main_repo_prefix = "@@//" if _is_bzlmod_enabled else "@//"
 
 def _adjust_main_repo_prefix(target_pattern):
     """Updates the main repository prefix to match the current Bazel version.
@@ -206,6 +208,7 @@ modules = struct(
     repo_name = _repo_name,
     apparent_repo_name = _apparent_repo_name,
     apparent_repo_label_string = _apparent_repo_label_string,
+    is_bzlmod_enabled = _is_bzlmod_enabled,
     main_repo_prefix = _main_repo_prefix,
     adjust_main_repo_prefix = _adjust_main_repo_prefix,
 )

--- a/lib/modules.bzl
+++ b/lib/modules.bzl
@@ -187,5 +187,5 @@ modules = struct(
     apparent_repo_name = _apparent_repo_name,
     apparent_repo_label_string = _apparent_repo_label_string,
     main_repo_prefix = _main_repo_prefix,
-    adjust_main_repo_prefix = _adjust_main_repo_prefix
+    adjust_main_repo_prefix = _adjust_main_repo_prefix,
 )

--- a/lib/modules.bzl
+++ b/lib/modules.bzl
@@ -147,26 +147,8 @@ def _apparent_repo_name(label_or_name):
 
     return repo_name[delimiter_indices[-1] + 1:]
 
-def _apparent_repo_label_string(label):
-    """Return a Label string starting with its apparent repo name.
-
-    Args:
-        label: a Label instance
-
-    Returns:
-        str(label) with its canonical repository name replaced with its apparent
-            repository name
-    """
-    repo_name = getattr(label, _repo_attr).lstrip("@")
-    if len(repo_name) == 0:
-        return str(label)
-
-    label_str = "@" + str(label).lstrip("@")
-    return label_str.replace(repo_name, _apparent_repo_name(label))
-
 modules = struct(
     as_extension = _as_extension,
     use_all_repos = _use_all_repos,
     apparent_repo_name = _apparent_repo_name,
-    apparent_repo_label_string = _apparent_repo_label_string,
 )

--- a/lib/modules.bzl
+++ b/lib/modules.bzl
@@ -114,6 +114,24 @@ def _use_all_repos(module_ctx, reproducible = False):
         **extension_metadata_kwargs
     )
 
+def _repo_name(label_or_name):
+    """Utility to provide Label compatibility with Bazel 5.
+
+    Under Bazel 5, calls `Label.workspace_name`. Otherwise calls
+    `Label.repo_name`.
+
+    Args:
+        label_or_name: a Label or repository name string
+
+    Returns:
+        The repository name returned directly from the Label API, or the
+            original string if not a Label
+    """
+    if hasattr(label_or_name, "repo_name"):
+        return label_or_name.repo_name
+
+    return getattr(label_or_name, "workspace_name", label_or_name)
+
 def _apparent_repo_name(label_or_name):
     """Return a repository's apparent repository name.
 
@@ -123,7 +141,7 @@ def _apparent_repo_name(label_or_name):
     Returns:
         The apparent repository name
     """
-    repo_name = getattr(label_or_name, "repo_name", label_or_name).lstrip("@")
+    repo_name = _repo_name(label_or_name).lstrip("@")
     delimiter_indices = []
 
     # Bazed on this pattern from the Bazel source:
@@ -153,13 +171,14 @@ def _apparent_repo_label_string(label):
         str(label) with its canonical repository name replaced with its apparent
             repository name
     """
-    if len(label.repo_name) == 0:
+    repo_name = _repo_name(label)
+    if len(repo_name) == 0:
         return str(label)
 
     label_str = "@" + str(label).lstrip("@")
-    return label_str.replace(label.repo_name, _apparent_repo_name(label))
+    return label_str.replace(repo_name, _apparent_repo_name(label))
 
-_main_repo_prefix = str(Label("@@//:all")).split(":")[0]
+_main_repo_prefix = str(Label("//:all")).split(":")[0]
 
 def _adjust_main_repo_prefix(target_pattern):
     """Updates the main repository prefix to match the current Bazel version.
@@ -184,6 +203,7 @@ def _adjust_main_repo_prefix(target_pattern):
 modules = struct(
     as_extension = _as_extension,
     use_all_repos = _use_all_repos,
+    repo_name = _repo_name,
     apparent_repo_name = _apparent_repo_name,
     apparent_repo_label_string = _apparent_repo_label_string,
     main_repo_prefix = _main_repo_prefix,

--- a/lib/modules.bzl
+++ b/lib/modules.bzl
@@ -114,7 +114,78 @@ def _use_all_repos(module_ctx, reproducible = False):
         **extension_metadata_kwargs
     )
 
+def _apparent_repo_name(label_or_name):
+    """Return a repository's apparent repository name.
+
+    Args:
+        label_or_name: a Label or repository name string
+
+    Returns:
+        The apparent repository name
+    """
+    repo_name = getattr(label_or_name, "repo_name", label_or_name).lstrip("@")
+    delimiter_indices = []
+
+    # Bazed on this pattern from the Bazel source:
+    # com.google.devtools.build.lib.cmdline.RepositoryName.VALID_REPO_NAME
+    for i in range(len(repo_name)):
+        c = repo_name[i]
+        if not (c.isalnum() or c in "_-."):
+            delimiter_indices.append(i)
+
+    if len(delimiter_indices) == 0:
+        # Already an apparent repo name, apparently.
+        return repo_name
+
+    if len(delimiter_indices) == 1:
+        # The name is for a top level module, possibly containing a version ID.
+        return repo_name[:delimiter_indices[0]]
+
+    return repo_name[delimiter_indices[-1] + 1:]
+
+def _apparent_repo_label_string(label):
+    """Return a Label string starting with its apparent repo name.
+
+    Args:
+        label: a Label instance
+
+    Returns:
+        str(label) with its canonical repository name replaced with its apparent
+            repository name
+    """
+    if len(label.repo_name) == 0:
+        return str(label)
+
+    label_str = "@" + str(label).lstrip("@")
+    return label_str.replace(label.repo_name, _apparent_repo_name(label))
+
+_main_repo_prefix = str(Label("@@//:all")).split(":")[0]
+
+def _adjust_main_repo_prefix(target_pattern):
+    """Updates the main repository prefix to match the current Bazel version.
+
+    The main repo prefix will be "@//" for Bazel < 7.1.0, and "@@//" for Bazel
+    >= 7.1.0 under Bzlmod. This macro automatically updates strings representing
+    include/exclude target patterns so that they match actual main repository
+    target Labels correctly.
+
+    Args:
+        target_pattern: a string used to match a BUILD target pattern
+
+    Returns:
+        the string with any main repository prefix updated to match the current
+            Bazel version
+    """
+    if target_pattern.startswith("@//") or target_pattern.startswith("@@//"):
+        return _main_repo_prefix + target_pattern.lstrip("@/")
+
+    return target_pattern
+
 modules = struct(
     as_extension = _as_extension,
     use_all_repos = _use_all_repos,
+    apparent_repo_name = _apparent_repo_name,
+    apparent_repo_label_string = _apparent_repo_label_string,
+    main_repo_prefix = _main_repo_prefix,
+    adjust_main_repo_prefix = _adjust_main_repo_prefix
 )

--- a/tests/extensions/apparent_repo_name.bzl
+++ b/tests/extensions/apparent_repo_name.bzl
@@ -13,7 +13,7 @@ apparent_repo_name_test_repo = repository_rule(
     _apparent_repo_name_test_repo_impl,
 )
 
-def apparent_repo_name_test_macro(*args):
+def apparent_repo_name_test_macro():
     apparent_repo_name_test_repo(name = "apparent-repo-name-test")
 
 apparent_repo_name_test_ext = module_extension(

--- a/tests/extensions/apparent_repo_name.bzl
+++ b/tests/extensions/apparent_repo_name.bzl
@@ -1,0 +1,22 @@
+"""Repo rule and module extension used to test modules.apparent_repo_name"""
+
+load("//lib:modules.bzl", "modules")
+
+def _apparent_repo_name_test_repo_impl(repository_ctx):
+    repo_name = modules.apparent_repo_name(repository_ctx)
+    test_file = "repo-name.bzl"
+    repository_ctx.file("WORKSPACE")
+    repository_ctx.file("BUILD", """exports_files(["%s"])""" % test_file)
+    repository_ctx.file(test_file, "REPO_NAME = \"%s\"" % repo_name)
+
+apparent_repo_name_test_repo = repository_rule(
+    _apparent_repo_name_test_repo_impl,
+)
+
+def apparent_repo_name_test_macro(*args):
+    apparent_repo_name_test_repo(name = "apparent-repo-name-test")
+
+apparent_repo_name_test_ext = module_extension(
+    lambda _: apparent_repo_name_test_macro(),
+    doc = "Only used for testing modules.apparent_repo_name()",
+)

--- a/tests/modules_test.bzl
+++ b/tests/modules_test.bzl
@@ -15,7 +15,10 @@
 """Test usage of modules.bzl."""
 
 load("//lib:modules.bzl", "modules")
+load("//lib:unittest.bzl", "asserts", "unittest")
 load("//rules:build_test.bzl", "build_test")
+
+_is_bzlmod_enabled = str(Label("//tests:module_tests.bzl")).startswith("@@")
 
 def _repo_rule_impl(repository_ctx):
     repository_ctx.file("WORKSPACE")
@@ -45,12 +48,158 @@ use_all_repos_test_ext = module_extension(
     doc = "Only used for testing modules.use_all_repos().",
 )
 
+def _apparent_repo_name_test(ctx):
+    """Unit tests for modules.apparent_repo_name."""
+    env = unittest.begin(ctx)
+
+    asserts.equals(
+        env, "", modules.apparent_repo_name(""),
+        msg = "Handles the empty string as input",
+    )
+
+    asserts.equals(
+        env, "foo", modules.apparent_repo_name("foo"),
+        msg = (
+            "Return the original name unchanged if it doesn't start with `@`.",
+        ),
+    )
+
+    asserts.equals(
+        env, "foo", modules.apparent_repo_name("@foo"),
+        msg = "Return the original name without `@` if already apparent.",
+    )
+
+    asserts.equals(
+        env, "foo", modules.apparent_repo_name(Label("@foo").repo_name),
+        msg = "Return the apparent name from a canonical name string.",
+    )
+
+    asserts.equals(
+        env, "", modules.apparent_repo_name(Label("@@//:all")),
+        msg = "Returns the empty string for a main repository Label.",
+    )
+
+    asserts.equals(
+        env, "", modules.apparent_repo_name(Label("@bazel_skylib//:all")),
+        msg = " ".join([
+            "Returns the empty string for a Label containing the main",
+            "repository's module name.",
+        ]),
+    )
+
+    asserts.equals(
+        env, "foo", modules.apparent_repo_name(Label("@foo")),
+        msg = "Return the apparent name from a Label.",
+    )
+
+    asserts.equals(
+        env, "rules_pkg", modules.apparent_repo_name(Label("@rules_pkg")),
+        msg = " ".join([
+            "Top level module repos have the canonical name delimiter at the",
+            "end. Therefore, this should not return the empty string, but the",
+            "name without the leading `@` and trailing delimiter.",
+        ]),
+    )
+
+    asserts.equals(
+        env,
+        "stardoc" if _is_bzlmod_enabled else "io_bazel_stardoc",
+        modules.apparent_repo_name(Label("@io_bazel_stardoc")),
+        msg = " ".join([
+            "Label values will already map bazel_dep repo_names to",
+            "actual repo names under Bzlmod (no-op under WORKSPACE)."
+        ])
+    )
+
+    asserts.equals(
+        env, "foo", modules.apparent_repo_name("foo+1.2.3"),
+        msg = "Ignores version numbers in canonical repo names",
+    )
+
+    return unittest.end(env)
+
+apparent_repo_name_test = unittest.make(_apparent_repo_name_test)
+
+def _apparent_repo_label_string_test(ctx):
+    """Unit tests for modules.apparent_repo_label_string."""
+    env = unittest.begin(ctx)
+
+    main_repo = str(Label("//:all"))
+    asserts.equals(
+        env, main_repo, modules.apparent_repo_label_string(Label("//:all")),
+        msg = "Returns top level target with leading `@` or `@@`",
+    )
+
+    main_module_label = Label("@bazel_skylib//:all")
+    asserts.equals(
+        env, main_repo, modules.apparent_repo_label_string(main_module_label),
+        msg = " ".join([
+            "Returns top level target with leading `@` or `@@`",
+            "for a Label containing the main module's name",
+        ]),
+    )
+
+    rules_pkg = "@rules_pkg//:all"
+    asserts.equals(
+        env, rules_pkg, modules.apparent_repo_label_string(Label(rules_pkg)),
+        msg = "Returns original repo name",
+    )
+
+    asserts.equals(
+        env,
+        "@%s//:all" % ("stardoc" if _is_bzlmod_enabled else "io_bazel_stardoc"),
+        modules.apparent_repo_label_string(Label("@io_bazel_stardoc//:all")),
+        msg = " ".join([
+            "Returns the actual module name instead of",
+            "repo_name from bazel_dep() (no-op under WORKSPACE).",
+        ]),
+    )
+
+    return unittest.end(env)
+
+apparent_repo_label_string_test = unittest.make(
+    _apparent_repo_label_string_test
+)
+
+def _adjust_main_repo_prefix_test(ctx):
+    """Unit tests for modules.apparent_repo_label_string."""
+    env = unittest.begin(ctx)
+
+    expected = modules.main_repo_prefix + ":all"
+    asserts.equals(
+        env, expected, modules.adjust_main_repo_prefix("@//:all"),
+        msg = "Normalizes a target pattern starting with `@//`.",
+    )
+
+    asserts.equals(
+        env, expected, modules.adjust_main_repo_prefix("@@//:all"),
+        msg = "Normalizes a target pattern starting with `@@//`.",
+    )
+
+    original = "@not_the_main_repo"
+    asserts.equals(
+        env, original, modules.adjust_main_repo_prefix(original),
+        msg = "Returns non main repo target patterns unchanged.",
+    )
+
+    return unittest.end(env)
+
+adjust_main_repo_prefix_test = unittest.make(
+    _adjust_main_repo_prefix_test
+)
+
 # buildifier: disable=unnamed-macro
 def modules_test_suite():
     """Creates the tests for modules.bzl if Bzlmod is enabled."""
 
-    is_bzlmod_enabled = str(Label("//tests:module_tests.bzl")).startswith("@@")
-    if not is_bzlmod_enabled:
+    unittest.suite(
+        "modules_tests",
+        apparent_repo_name_test,
+        apparent_repo_label_string_test,
+        adjust_main_repo_prefix_test,
+    )
+
+    if not _is_bzlmod_enabled:
         return
 
     build_test(

--- a/tests/modules_test.bzl
+++ b/tests/modules_test.bzl
@@ -18,8 +18,6 @@ load("//lib:modules.bzl", "modules")
 load("//lib:unittest.bzl", "asserts", "unittest")
 load("//rules:build_test.bzl", "build_test")
 
-_is_bzlmod_enabled = str(Label("//tests:module_tests.bzl")).startswith("@@")
-
 def _repo_rule_impl(repository_ctx):
     repository_ctx.file("WORKSPACE")
     repository_ctx.file("BUILD", """exports_files(["hello"])""")
@@ -119,7 +117,7 @@ def _apparent_repo_name_test(ctx):
 
     asserts.equals(
         env,
-        "stardoc" if _is_bzlmod_enabled else "io_bazel_stardoc",
+        "stardoc" if modules.is_bzlmod_enabled else "io_bazel_stardoc",
         modules.apparent_repo_name(Label("@io_bazel_stardoc")),
         msg = " ".join([
             "Label values will already map bazel_dep repo_names to",
@@ -171,7 +169,9 @@ def _apparent_repo_label_string_test(ctx):
 
     asserts.equals(
         env,
-        "@%s//:all" % ("stardoc" if _is_bzlmod_enabled else "io_bazel_stardoc"),
+        "@%s//:all" % (
+            "stardoc" if modules.is_bzlmod_enabled else "io_bazel_stardoc"
+        ),
         modules.apparent_repo_label_string(Label("@io_bazel_stardoc//:all")),
         msg = " ".join([
             "Returns the actual module name instead of",
@@ -229,7 +229,7 @@ def modules_test_suite():
         adjust_main_repo_prefix_test,
     )
 
-    if not _is_bzlmod_enabled:
+    if not modules.is_bzlmod_enabled:
         return
 
     build_test(

--- a/tests/modules_test.bzl
+++ b/tests/modules_test.bzl
@@ -53,34 +53,46 @@ def _apparent_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
     asserts.equals(
-        env, "", modules.apparent_repo_name(""),
+        env,
+        "",
+        modules.apparent_repo_name(""),
         msg = "Handles the empty string as input",
     )
 
     asserts.equals(
-        env, "foo", modules.apparent_repo_name("foo"),
+        env,
+        "foo",
+        modules.apparent_repo_name("foo"),
         msg = (
             "Return the original name unchanged if it doesn't start with `@`.",
         ),
     )
 
     asserts.equals(
-        env, "foo", modules.apparent_repo_name("@foo"),
+        env,
+        "foo",
+        modules.apparent_repo_name("@foo"),
         msg = "Return the original name without `@` if already apparent.",
     )
 
     asserts.equals(
-        env, "foo", modules.apparent_repo_name(Label("@foo").repo_name),
+        env,
+        "foo",
+        modules.apparent_repo_name(Label("@foo").repo_name),
         msg = "Return the apparent name from a canonical name string.",
     )
 
     asserts.equals(
-        env, "", modules.apparent_repo_name(Label("@@//:all")),
+        env,
+        "",
+        modules.apparent_repo_name(Label("@@//:all")),
         msg = "Returns the empty string for a main repository Label.",
     )
 
     asserts.equals(
-        env, "", modules.apparent_repo_name(Label("@bazel_skylib//:all")),
+        env,
+        "",
+        modules.apparent_repo_name(Label("@bazel_skylib//:all")),
         msg = " ".join([
             "Returns the empty string for a Label containing the main",
             "repository's module name.",
@@ -88,12 +100,16 @@ def _apparent_repo_name_test(ctx):
     )
 
     asserts.equals(
-        env, "foo", modules.apparent_repo_name(Label("@foo")),
+        env,
+        "foo",
+        modules.apparent_repo_name(Label("@foo")),
         msg = "Return the apparent name from a Label.",
     )
 
     asserts.equals(
-        env, "rules_pkg", modules.apparent_repo_name(Label("@rules_pkg")),
+        env,
+        "rules_pkg",
+        modules.apparent_repo_name(Label("@rules_pkg")),
         msg = " ".join([
             "Top level module repos have the canonical name delimiter at the",
             "end. Therefore, this should not return the empty string, but the",
@@ -107,12 +123,14 @@ def _apparent_repo_name_test(ctx):
         modules.apparent_repo_name(Label("@io_bazel_stardoc")),
         msg = " ".join([
             "Label values will already map bazel_dep repo_names to",
-            "actual repo names under Bzlmod (no-op under WORKSPACE)."
-        ])
+            "actual repo names under Bzlmod (no-op under WORKSPACE).",
+        ]),
     )
 
     asserts.equals(
-        env, "foo", modules.apparent_repo_name("foo+1.2.3"),
+        env,
+        "foo",
+        modules.apparent_repo_name("foo+1.2.3"),
         msg = "Ignores version numbers in canonical repo names",
     )
 
@@ -126,13 +144,17 @@ def _apparent_repo_label_string_test(ctx):
 
     main_repo = str(Label("//:all"))
     asserts.equals(
-        env, main_repo, modules.apparent_repo_label_string(Label("//:all")),
+        env,
+        main_repo,
+        modules.apparent_repo_label_string(Label("//:all")),
         msg = "Returns top level target with leading `@` or `@@`",
     )
 
     main_module_label = Label("@bazel_skylib//:all")
     asserts.equals(
-        env, main_repo, modules.apparent_repo_label_string(main_module_label),
+        env,
+        main_repo,
+        modules.apparent_repo_label_string(main_module_label),
         msg = " ".join([
             "Returns top level target with leading `@` or `@@`",
             "for a Label containing the main module's name",
@@ -141,7 +163,9 @@ def _apparent_repo_label_string_test(ctx):
 
     rules_pkg = "@rules_pkg//:all"
     asserts.equals(
-        env, rules_pkg, modules.apparent_repo_label_string(Label(rules_pkg)),
+        env,
+        rules_pkg,
+        modules.apparent_repo_label_string(Label(rules_pkg)),
         msg = "Returns original repo name",
     )
 
@@ -158,7 +182,7 @@ def _apparent_repo_label_string_test(ctx):
     return unittest.end(env)
 
 apparent_repo_label_string_test = unittest.make(
-    _apparent_repo_label_string_test
+    _apparent_repo_label_string_test,
 )
 
 def _adjust_main_repo_prefix_test(ctx):
@@ -167,25 +191,31 @@ def _adjust_main_repo_prefix_test(ctx):
 
     expected = modules.main_repo_prefix + ":all"
     asserts.equals(
-        env, expected, modules.adjust_main_repo_prefix("@//:all"),
+        env,
+        expected,
+        modules.adjust_main_repo_prefix("@//:all"),
         msg = "Normalizes a target pattern starting with `@//`.",
     )
 
     asserts.equals(
-        env, expected, modules.adjust_main_repo_prefix("@@//:all"),
+        env,
+        expected,
+        modules.adjust_main_repo_prefix("@@//:all"),
         msg = "Normalizes a target pattern starting with `@@//`.",
     )
 
     original = "@not_the_main_repo"
     asserts.equals(
-        env, original, modules.adjust_main_repo_prefix(original),
+        env,
+        original,
+        modules.adjust_main_repo_prefix(original),
         msg = "Returns non main repo target patterns unchanged.",
     )
 
     return unittest.end(env)
 
 adjust_main_repo_prefix_test = unittest.make(
-    _adjust_main_repo_prefix_test
+    _adjust_main_repo_prefix_test,
 )
 
 # buildifier: disable=unnamed-macro

--- a/tests/modules_test.bzl
+++ b/tests/modules_test.bzl
@@ -143,55 +143,6 @@ def _apparent_repo_name_test(ctx):
 
 apparent_repo_name_test = unittest.make(_apparent_repo_name_test)
 
-def _apparent_repo_label_string_test(ctx):
-    """Unit tests for modules.apparent_repo_label_string."""
-    env = unittest.begin(ctx)
-
-    main_repo = str(Label("//:all"))
-    asserts.equals(
-        env,
-        main_repo,
-        modules.apparent_repo_label_string(Label("//:all")),
-        msg = "Returns top level target with leading `@` or `@@`",
-    )
-
-    main_module_label = Label("@bazel_skylib//:all")
-    asserts.equals(
-        env,
-        main_repo,
-        modules.apparent_repo_label_string(main_module_label),
-        msg = " ".join([
-            "Returns top level target with leading `@` or `@@`",
-            "for a Label containing the main module's name",
-        ]),
-    )
-
-    rules_pkg = "@rules_pkg//:all"
-    asserts.equals(
-        env,
-        rules_pkg,
-        modules.apparent_repo_label_string(Label(rules_pkg)),
-        msg = "Returns original repo name",
-    )
-
-    asserts.equals(
-        env,
-        "@%s//:all" % (
-            "stardoc" if _is_bzlmod_enabled else "io_bazel_stardoc"
-        ),
-        modules.apparent_repo_label_string(Label("@io_bazel_stardoc//:all")),
-        msg = " ".join([
-            "Returns the actual module name instead of",
-            "repo_name from bazel_dep() (no-op under WORKSPACE).",
-        ]),
-    )
-
-    return unittest.end(env)
-
-apparent_repo_label_string_test = unittest.make(
-    _apparent_repo_label_string_test,
-)
-
 # buildifier: disable=unnamed-macro
 def modules_test_suite():
     """Creates the tests for modules.bzl if Bzlmod is enabled."""
@@ -199,7 +150,6 @@ def modules_test_suite():
     unittest.suite(
         "modules_tests",
         apparent_repo_name_test,
-        apparent_repo_label_string_test,
     )
 
     if not _is_bzlmod_enabled:

--- a/tests/modules_test.bzl
+++ b/tests/modules_test.bzl
@@ -14,6 +14,7 @@
 
 """Test usage of modules.bzl."""
 
+load("@apparent-repo-name-test//:repo-name.bzl", "REPO_NAME")
 load("//lib:modules.bzl", "modules")
 load("//lib:unittest.bzl", "asserts", "unittest")
 load("//rules:build_test.bzl", "build_test")
@@ -54,89 +55,12 @@ def _apparent_repo_name_test(ctx):
 
     asserts.equals(
         env,
-        "",
-        modules.apparent_repo_name(""),
-        msg = "Handles the empty string as input",
-    )
-
-    asserts.equals(
-        env,
-        "foo",
-        modules.apparent_repo_name("foo"),
-        msg = (
-            "Return the original name unchanged if it doesn't start with `@`.",
-        ),
-    )
-
-    asserts.equals(
-        env,
-        "foo",
-        modules.apparent_repo_name("@foo"),
-        msg = "Return the original name without `@` if already apparent.",
-    )
-
-    foo_label = Label("@foo")
-    foo_canonical_name = getattr(
-        foo_label,
-        "repo_name" if hasattr(foo_label, "repo_name") else "workspace_name",
-    )
-    asserts.equals(
-        env,
-        "foo",
-        modules.apparent_repo_name(foo_canonical_name),
-        msg = "Return the apparent name from a canonical name string.",
-    )
-
-    asserts.equals(
-        env,
-        "",
-        modules.apparent_repo_name(Label("//:all")),
-        msg = "Returns the empty string for a main repository Label.",
-    )
-
-    asserts.equals(
-        env,
-        "",
-        modules.apparent_repo_name(Label("@bazel_skylib//:all")),
+        "apparent-repo-name-test",
+        REPO_NAME,
         msg = " ".join([
-            "Returns the empty string for a Label containing the main",
-            "repository's module name.",
+            "Returns the original name unchanged under WORKSPACE, and",
+            "the apparent repo name under Bzlmod.",
         ]),
-    )
-
-    asserts.equals(
-        env,
-        "foo",
-        modules.apparent_repo_name(Label("@foo")),
-        msg = "Return the apparent name from a Label.",
-    )
-
-    asserts.equals(
-        env,
-        "rules_pkg",
-        modules.apparent_repo_name(Label("@rules_pkg")),
-        msg = " ".join([
-            "Top level module repos have the canonical name delimiter at the",
-            "end. Therefore, this should not return the empty string, but the",
-            "name without the leading `@` and trailing delimiter.",
-        ]),
-    )
-
-    asserts.equals(
-        env,
-        "stardoc" if _is_bzlmod_enabled else "io_bazel_stardoc",
-        modules.apparent_repo_name(Label("@io_bazel_stardoc")),
-        msg = " ".join([
-            "Label values will already map bazel_dep repo_names to",
-            "actual repo names under Bzlmod (no-op under WORKSPACE).",
-        ]),
-    )
-
-    asserts.equals(
-        env,
-        "foo",
-        modules.apparent_repo_name("foo+1.2.3"),
-        msg = "Ignores version numbers in canonical repo names",
     )
 
     return unittest.end(env)

--- a/tests/modules_test.bzl
+++ b/tests/modules_test.bzl
@@ -78,14 +78,14 @@ def _apparent_repo_name_test(ctx):
     asserts.equals(
         env,
         "foo",
-        modules.apparent_repo_name(Label("@foo").repo_name),
+        modules.apparent_repo_name(modules.repo_name(Label("@foo"))),
         msg = "Return the apparent name from a canonical name string.",
     )
 
     asserts.equals(
         env,
         "",
-        modules.apparent_repo_name(Label("@@//:all")),
+        modules.apparent_repo_name(Label("//:all")),
         msg = "Returns the empty string for a main repository Label.",
     )
 


### PR DESCRIPTION
Adds the `apparent_repo_name` macro to derive the apparent name from `repository_ctx.name` when running under Bzlmod. This enables repository rules to generate their own top level default target without requiring a redundant parameter.

Originally developed while updating rules_scala to support Bzlmod as part of bazelbuild/rules_scala#1482.

For examples of its use, see bazelbuild/rules_scala#1621.

---

BTW, I happened to put it in the `modules` lib, as that seemed like the best fit at the time. Happy to move it elsewhere.

cc: @BillyAutrey @jayconrod @benjaminp @TheGrizzlyDev