### PR TITLE
Bump `rules_license` to 1.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,7 @@ register_toolchains(
 )
 
 bazel_dep(name = "platforms", version = "0.0.4")
-bazel_dep(name = "rules_license", version = "0.0.7")
+bazel_dep(name = "rules_license", version = "1.0.0")
 
 ### INTERNAL ONLY - lines after this are not included in the release packaging.
 

--- a/workspace.bzl
+++ b/workspace.bzl
@@ -23,10 +23,10 @@ def bazel_skylib_workspace():
     maybe(
         http_archive,
         name = "rules_license",
-        sha256 = "4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360",
+        sha256 = "26d4021f6898e23b82ef953078389dd49ac2b5618ac564ade4ef87cced147b38",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
-            "https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",
+            "https://github.com/bazelbuild/rules_license/releases/download/1.0.0/rules_license-1.0.0.tar.gz",
         ],
     )
     register_unittest_toolchains()


### PR DESCRIPTION
This brings in the `purl` field that is increasingly used by other libraries. In the `bzlmod` world this is less important, but for folks using workspace-based builds, skylib tends to be loaded early so any deps it brings in normally end up being used.