### PR TITLE
Remove obsolete bazel 4.x compat code

### DIFF
--- a/rules/native_binary.bzl
+++ b/rules/native_binary.bzl
@@ -29,17 +29,10 @@ def _impl_rule(ctx):
     )
     runfiles = ctx.runfiles(files = ctx.files.data)
 
-    # Bazel 4.x LTS does not support `merge_all`.
-    # TODO: remove `merge` branch once we drop support for Bazel 4.x.
-    if hasattr(runfiles, "merge_all"):
-        runfiles = runfiles.merge_all([
-            d[DefaultInfo].default_runfiles
-            for d in ctx.attr.data + [ctx.attr.src]
-        ])
-    else:
-        for d in ctx.attr.data:
-            runfiles = runfiles.merge(d[DefaultInfo].default_runfiles)
-        runfiles = runfiles.merge(ctx.attr.src[DefaultInfo].default_runfiles)
+    runfiles = runfiles.merge_all([
+        d[DefaultInfo].default_runfiles
+        for d in ctx.attr.data + [ctx.attr.src]
+    ])
 
     return DefaultInfo(
         executable = out,


### PR DESCRIPTION
Bazel 4.x support has ended with https://github.com/bazelbuild/bazel-skylib/releases/tag/1.2.1.