### PR TITLE
Add new "env" variable to native_* rules

### DIFF
--- a/docs/native_binary_doc.md
+++ b/docs/native_binary_doc.md
@@ -14,7 +14,7 @@ don't depend on Bash and work with --shell_executable="".
 <pre>
 load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
 
-native_binary(<a href="#native_binary-name">name</a>, <a href="#native_binary-src">src</a>, <a href="#native_binary-data">data</a>, <a href="#native_binary-out">out</a>)
+native_binary(<a href="#native_binary-name">name</a>, <a href="#native_binary-src">src</a>, <a href="#native_binary-data">data</a>, <a href="#native_binary-out">out</a>, <a href="#native_binary-env">env</a>)
 </pre>
 
 Wraps a pre-built binary or script with a binary rule.
@@ -31,6 +31,7 @@ in genrule.tools for example. You can also augment the binary with runfiles.
 | <a id="native_binary-src"></a>src |  path of the pre-built executable   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="native_binary-data"></a>data |  data dependencies. See https://bazel.build/reference/be/common-definitions#typical.data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="native_binary-out"></a>out |  An output name for the copy of the binary. Defaults to name.exe. (We add .exe to the name by default because it's required on Windows and tolerated on other platforms.)   | String | optional |  `""`  |
+| <a id="native_binary-env"></a>env |  Environment variables to set when running the binary.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 
 
 <a id="native_test"></a>
@@ -40,7 +41,7 @@ in genrule.tools for example. You can also augment the binary with runfiles.
 <pre>
 load("@bazel_skylib//rules:native_binary.bzl", "native_test")
 
-native_test(<a href="#native_test-name">name</a>, <a href="#native_test-src">src</a>, <a href="#native_test-data">data</a>, <a href="#native_test-out">out</a>)
+native_test(<a href="#native_test-name">name</a>, <a href="#native_test-src">src</a>, <a href="#native_test-data">data</a>, <a href="#native_test-out">out</a>, <a href="#native_test-env">env</a>)
 </pre>
 
 Wraps a pre-built binary or script with a test rule.
@@ -57,5 +58,6 @@ the binary with runfiles.
 | <a id="native_test-src"></a>src |  path of the pre-built executable   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="native_test-data"></a>data |  data dependencies. See https://bazel.build/reference/be/common-definitions#typical.data   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="native_test-out"></a>out |  An output name for the copy of the binary. Defaults to name.exe. (We add .exe to the name by default because it's required on Windows and tolerated on other platforms.)   | String | optional |  `""`  |
+| <a id="native_test-env"></a>env |  Environment variables to set when running the binary.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
 
 

--- a/rules/native_binary.bzl
+++ b/rules/native_binary.bzl
@@ -34,11 +34,16 @@ def _impl_rule(ctx):
         for d in ctx.attr.data + [ctx.attr.src]
     ])
 
-    return DefaultInfo(
-        executable = out,
-        files = depset([out]),
-        runfiles = runfiles,
-    )
+    return [
+        DefaultInfo(
+            executable = out,
+            files = depset([out]),
+            runfiles = runfiles,
+        ),
+        RunEnvironmentInfo(
+            environment = ctx.attr.env,
+        ),
+    ]
 
 _ATTRS = {
     "src": attr.label(
@@ -62,6 +67,9 @@ _ATTRS = {
         doc = "An output name for the copy of the binary. Defaults to " +
               "name.exe. (We add .exe to the name by default because it's " +
               "required on Windows and tolerated on other platforms.)",
+    ),
+    "env": attr.string_dict(
+        doc = "Environment variables to set when running the binary.",
     ),
 }
 

--- a/tests/native_binary/BUILD
+++ b/tests/native_binary/BUILD
@@ -55,6 +55,23 @@ copy_file(
     is_executable = True,
 )
 
+cc_binary(
+    name = "assertenv",
+    srcs = ["assertenv.cc"],
+)
+
+# A rule that copies "assertenv"'s output as an opaque executable, simulating a
+# binary that's not built from source and needs to be wrapped in native_binary.
+copy_file(
+    name = "copy_assertenv_exe",
+    src = ":assertenv",
+    # On Windows we need the ".exe" extension.
+    # On other platforms the extension doesn't matter.
+    # Therefore we can use ".exe" on every platform.
+    out = "assertenv_copy.exe",
+    is_executable = True,
+)
+
 _ARGS = [
     "'a b'",
     "c\\ d",
@@ -121,4 +138,24 @@ native_test(
     # On other platforms the extension doesn't matter.
     # Therefore we can use ".exe" on every platform.
     out = "data_from_binary_test.exe",
+)
+
+native_binary(
+    name = "env_bin",
+    src = ":copy_assertenv_exe",
+    # On Windows we need the ".exe" extension.
+    # On other platforms the extension doesn't matter.
+    # Therefore we can use ".exe" on every platform.
+    out = "env_bin.exe",
+    env = {"TEST_ENV_VAR": "ENV_VALUE"},
+)
+
+native_test(
+    name = "env_test",
+    src = ":copy_assertenv_exe",
+    # On Windows we need the ".exe" extension.
+    # On other platforms the extension doesn't matter.
+    # Therefore we can use ".exe" on every platform.
+    out = "env_test.exe",
+    env = {"TEST_ENV_VAR": "ENV_VALUE"},
 )

--- a/tests/native_binary/assertenv.cc
+++ b/tests/native_binary/assertenv.cc
@@ -1,0 +1,38 @@
+// Copyright 2019 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <utility>
+
+int main(int argc, char** argv) {
+  static const std::pair<const char*, const char*> kExpected[] = {
+      {"TEST_ENV_VAR", "ENV_VALUE"}};
+
+  for (auto expected : kExpected) {
+    const char* key = expected.first;
+    const char* value = expected.second;
+    if (strcmp(getenv(key), value)) {
+      fprintf(stderr, "Expected %s to be %s, but it was %s\n", key, value,
+              getenv(key));
+      return 1;
+    } else {
+      printf("key[%s]=(%s) OK\n", key, value);
+    }
+  }
+  return 0;
+}
+


### PR DESCRIPTION
This (standard) variable "env" allows the propagation of environment variables to the test being executed or tested.