### PR TITLE
feat: generate doc_extract targets

### DIFF
--- a/bzl_library.bzl
+++ b/bzl_library.bzl
@@ -23,7 +23,7 @@ load(
 
 StarlarkLibraryInfo = _StarlarkLibraryInfo
 
-def bzl_library(name, **kwargs):
+def bzl_library(name, srcs = [], deps = [], **kwargs):
     """Wrapper for bzl_library.
 
     Args:
@@ -36,11 +36,21 @@ def bzl_library(name, **kwargs):
     _ = kwargs.pop("exec_compatible_with", None)
     _ = kwargs.pop("features", None)
     _ = kwargs.pop("target_compatible_with", None)
+    
     _bzl_library(
         name = name,
+        srcs = srcs,
+        deps = deps,
         compatible_with = [],
         exec_compatible_with = [],
         features = [],
         target_compatible_with = [],
         **kwargs
     )
+    
+    for src in srcs:
+        native.starlark_doc_extract(
+            name = "{}.doc_extract{}".format(name, "_" + src if len(srcs) > 1 else ""),
+            src = src,
+            deps = deps,
+        )


### PR DESCRIPTION
Allows bzl_library targets to produce documentation without needing to load stardoc or add additional targets. Note, it would be better to do this with an aspect that visits the bzl_library graph, but the starlark_doc_extract rule is in Bazel java core, and so we cannot spawn actions using its Java code. It needs a main() entry point.