### PR TITLE
Migrate away from `@bazel_tools//src/conditions:host_windows`

### DIFF
--- a/docs/diff_test_doc.md
+++ b/docs/diff_test_doc.md
@@ -12,23 +12,21 @@ command (fc.exe) on Windows (no Bash is required).
 <pre>
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 
-diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>, <a href="#diff_test-failure_message">failure_message</a>, <a href="#diff_test-kwargs">**kwargs</a>)
+diff_test(<a href="#diff_test-name">name</a>, <a href="#diff_test-failure_message">failure_message</a>, <a href="#diff_test-file1">file1</a>, <a href="#diff_test-file2">file2</a>)
 </pre>
 
 A test that compares two files.
 
 The test succeeds if the files' contents match.
 
+**ATTRIBUTES**
 
-**PARAMETERS**
 
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="diff_test-name"></a>name |  The name of the test rule.   |  none |
-| <a id="diff_test-file1"></a>file1 |  Label of the file to compare to `file2`.   |  none |
-| <a id="diff_test-file2"></a>file2 |  Label of the file to compare to `file1`.   |  none |
-| <a id="diff_test-failure_message"></a>failure_message |  Additional message to log if the files' contents do not match.   |  `None` |
-| <a id="diff_test-kwargs"></a>kwargs |  The [common attributes for tests](https://bazel.build/reference/be/common-definitions#common-attributes-tests).   |  none |
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="diff_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="diff_test-failure_message"></a>failure_message |  Additional message to log if the files' contents do not match.   | String | optional |  `""`  |
+| <a id="diff_test-file1"></a>file1 |  Label of the file to compare to `file2`.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="diff_test-file2"></a>file2 |  Label of the file to compare to `file1`.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 
 

--- a/rules/private/BUILD
+++ b/rules/private/BUILD
@@ -1,8 +1,11 @@
 load("//:bzl_library.bzl", "bzl_library")
+load(":copy_file_private.bzl", "is_windows")
 
 package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
+
+is_windows(name = "is_windows")
 
 bzl_library(
     name = "bzl_library",

--- a/tests/diff_test/diff_test_tests.sh
+++ b/tests/diff_test/diff_test_tests.sh
@@ -60,6 +60,9 @@ function assert_simple_diff_test() {
 
   import_diff_test "$ws"
   touch "$ws/WORKSPACE"
+  cat >"$ws/MODULE.bazel" <<'eof'
+bazel_dep(name = "platforms", version = "0.0.10")
+eof
   mkdir -p "$ws/$subdir"
   cat >"$ws/${subdir}BUILD" <<'eof'
 load("//rules:diff_test.bzl", "diff_test")
@@ -113,6 +116,7 @@ local_repository(
 )
 eof
   cat >"$ws/main/MODULE.bazel" <<'eof'
+bazel_dep(name = "platforms", version = "0.0.10")
 local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
 local_repository(
     name = "bzl",
@@ -249,6 +253,9 @@ function test_failure_message() {
 
   import_diff_test "$ws"
   touch "$ws/WORKSPACE"
+  cat >"$ws/MODULE.bazel" <<'eof'
+bazel_dep(name = "platforms", version = "0.0.10")
+eof
   cat >"$ws/BUILD" <<'eof'
 load("//rules:diff_test.bzl", "diff_test")
 

--- a/tests/run_binary/BUILD
+++ b/tests/run_binary/BUILD
@@ -77,7 +77,7 @@ write_file(
     # Therefore we can use ".bat" on every platform.
     out = "script.bat",
     content = select({
-        "@bazel_tools//src/conditions:host_windows": [
+        "@platforms//os:windows": [
             "@echo>%OUT% arg1=(%1)",
             "@echo>>%OUT% arg2=(%2)",
             "@echo>>%OUT% ENV_LOCATION=(%ENV_LOCATION%)",


### PR DESCRIPTION
The condition has been deprecated at HEAD. None of its usages in skylib were correct as they should all either match on the target or the exec platform, not the host.