### PR TITLE
Return runfiles from select_file

### DIFF
--- a/rules/select_file.bzl
+++ b/rules/select_file.bzl
@@ -34,7 +34,7 @@ def _impl(ctx):
             for f in ctx.attr.srcs.files.to_list()
         ])
         fail("Can not find specified file in [%s]" % files_str)
-    return [DefaultInfo(files = depset([out]))]
+    return [DefaultInfo(files = depset([out]), runfiles = ctx.runfiles(files = [out]))]
 
 select_file = rule(
     implementation = _impl,


### PR DESCRIPTION
This is essentially free and allows downstream rules that read runfiles to use a file selected with `select_file`.

To provide an example: I found that a `go_binary` will not pick up runfiles in its `data` dependencies if they come from `select_file` (using `bazel run`).