### PR TITLE
Make `is_windows` public

### DIFF
--- a/rules/private/BUILD
+++ b/rules/private/BUILD
@@ -5,7 +5,10 @@ package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
 
-is_windows(name = "is_windows")
+is_windows(
+    name = "is_windows",
+    visibility = ["//visibility:public"],
+)
 
 bzl_library(
     name = "bzl_library",


### PR DESCRIPTION
Not all supported Bazel versions correctly validate the visibility of a private attribute relative to the definition of the rule rather than the target.