### PR TITLE
Declare test toolchain requirements on the `test` exec group

### DIFF
--- a/lib/unittest.bzl
+++ b/lib/unittest.bzl
@@ -198,7 +198,10 @@ def _make(impl, attrs = {}, doc = "", toolchains = []):
         attrs = attrs,
         _skylark_testable = True,
         test = True,
-        toolchains = toolchains + [TOOLCHAIN_TYPE],
+        toolchains = toolchains,
+        exec_groups = {
+            "test": exec_group(toolchains = [TOOLCHAIN_TYPE]),
+        },
     )
 
 _ActionInfo = provider(
@@ -299,7 +302,9 @@ def _make_analysis_test(
         attrs = attrs,
         fragments = fragments,
         test = True,
-        toolchains = [TOOLCHAIN_TYPE],
+        exec_groups = {
+            "test": exec_group(toolchains = [TOOLCHAIN_TYPE]),
+        },
         analysis_test = True,
     )
 
@@ -429,7 +434,7 @@ def _end(env):
       A list of providers needed to automatically register the test result.
     """
 
-    tc = env.ctx.toolchains[TOOLCHAIN_TYPE].unittest_toolchain_info
+    tc = env.ctx.exec_groups["test"].toolchains[TOOLCHAIN_TYPE].unittest_toolchain_info
     testbin = env.ctx.actions.declare_file(env.ctx.label.name + tc.file_ext)
     if env.failures:
         failure_message_lines = "\n".join(env.failures).split("\n")
@@ -603,7 +608,7 @@ def _target_under_test(env):
     return result
 
 def _loading_test_impl(ctx):
-    tc = ctx.toolchains[TOOLCHAIN_TYPE].unittest_toolchain_info
+    tc = ctx.exec_groups["test"].toolchains[TOOLCHAIN_TYPE].unittest_toolchain_info
     content = tc.success_templ
     if ctx.attr.failure_message:
         content = tc.failure_templ % ctx.attr.failure_message
@@ -621,7 +626,9 @@ _loading_test = rule(
     attrs = {
         "failure_message": attr.string(),
     },
-    toolchains = [TOOLCHAIN_TYPE],
+    exec_groups = {
+        "test": exec_group(toolchains = [TOOLCHAIN_TYPE]),
+    },
     test = True,
 )
 

--- a/rules/analysis_test.bzl
+++ b/rules/analysis_test.bzl
@@ -27,6 +27,12 @@ analysis_test = rule(
     attrs = {"targets": attr.label_list(mandatory = True)},
     test = True,
     analysis_test = True,
+    exec_groups = {
+        # The default test exec groups limits test execution to an execution platform that matches
+        # the target platform's constraints. But the action Bazel uses to render the result of the
+        # test supports any platform, so we override this exec group to have no requirements.
+        "test": exec_group(),
+    },
     doc = """Test rule checking that other targets can be successfully analyzed.
 
     This rule essentially verifies that all targets under `targets` would


### PR DESCRIPTION
This ensures that unit and analysis tests can be executed on all platforms, regardless of the current target platform, even after https://github.com/bazelbuild/bazel/issues/25823.