### PR TITLE
Introduce repeatable_string_flag.

### DIFF
--- a/docs/common_settings_doc.md
+++ b/docs/common_settings_doc.md
@@ -115,7 +115,7 @@ A build setting that accepts one or more string-typed settings on the command li
 
 
 <a id="string_flag"></a>
-`
+
 ## string_flag
 
 <pre>

--- a/docs/common_settings_doc.md
+++ b/docs/common_settings_doc.md
@@ -105,6 +105,7 @@ repeatable_string_flag(<a href="#repeatable_string_flag-name">name</a>, <a href=
 </pre>
 
 A build setting that accepts one or more string-typed settings on the command line, with the values concatenated into a single string list; for example, `--//my/setting=foo` `--//my/setting=bar` will be parsed as `['foo', 'bar']`. Contrast with `string_list_flag`
+
 **ATTRIBUTES**
 
 
@@ -147,7 +148,8 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_list_flag")
 string_list_flag(<a href="#string_list_flag-name">name</a>, <a href="#string_list_flag-scope">scope</a>)
 </pre>
 
-A string list-typed build setting which expects its value on the command line to be given in comma-separated format; for example, `--//my/setting=foo,bar` will be parsed as `['foo', 'bar']`. Contrast with `repeatable_string_flag`.
+A string list-typed build setting that can be set on the command line
+
 **ATTRIBUTES**
 
 
@@ -167,7 +169,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_list_setting")
 string_list_setting(<a href="#string_list_setting-name">name</a>, <a href="#string_list_setting-scope">scope</a>)
 </pre>
 
-A string list-typed build setting that cannot be set on the command line
+A string list-typed build setting which expects its value on the command line to be given in comma-separated format; for example, `--//my/setting=foo,bar` will be parsed as `['foo', 'bar']`. Contrast with `repeatable_string_flag`
 
 **ATTRIBUTES**
 

--- a/docs/common_settings_doc.md
+++ b/docs/common_settings_doc.md
@@ -104,7 +104,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "repeatable_string_flag")
 repeatable_string_flag(<a href="#repeatable_string_flag-name">name</a>, <a href="#repeatable_string_flag-scope">scope</a>)
 </pre>
 
-A build setting that accepts one or more string-typed settings on the command line, with the values concatenated into a single string list; for example, `--//my/setting=foo` `--//my/setting=bar` will be parsed as `["foo", "bar"]`. Contrast with `string_list_flag`
+A build setting that accepts one or more string-typed settings on the command line, with the values concatenated into a single string list; for example, `--//my/setting=foo` `--//my/setting=bar` will be parsed as `['foo', 'bar']`. Contrast with `string_list_flag`
 **ATTRIBUTES**
 
 
@@ -147,7 +147,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_list_flag")
 string_list_flag(<a href="#string_list_flag-name">name</a>, <a href="#string_list_flag-scope">scope</a>)
 </pre>
 
-A string list-typed build setting which expects its value on the command line to be given in comma-separated format; for example, `--//my/setting=foo,bar` will be parsed as `["foo", "bar"]`. Contrast with `repeatable_string_flag`.
+A string list-typed build setting which expects its value on the command line to be given in comma-separated format; for example, `--//my/setting=foo,bar` will be parsed as `['foo', 'bar']`. Contrast with `repeatable_string_flag`.
 **ATTRIBUTES**
 
 

--- a/docs/common_settings_doc.md
+++ b/docs/common_settings_doc.md
@@ -94,6 +94,27 @@ An int-typed build setting that cannot be set on the command line
 | <a id="int_setting-scope"></a>scope |  The scope indicates where a flag can propagate to   | String | optional |  `"universal"`  |
 
 
+<a id="repeatable_string_flag"></a>
+
+## repeatable_string_flag
+
+<pre>
+load("@bazel_skylib//rules:common_settings.bzl", "repeatable_string_flag")
+
+repeatable_string_flag(<a href="#repeatable_string_flag-name">name</a>, <a href="#repeatable_string_flag-scope">scope</a>)
+</pre>
+
+A string-typed build setting that can be set on the command line. Multiple settings do not overwrite each other; they are concatenated into a list
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="repeatable_string_flag-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="repeatable_string_flag-scope"></a>scope |  The scope indicates where a flag can propagate to   | String | optional |  `"universal"`  |
+
+
 <a id="string_flag"></a>
 
 ## string_flag

--- a/docs/common_settings_doc.md
+++ b/docs/common_settings_doc.md
@@ -104,8 +104,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "repeatable_string_flag")
 repeatable_string_flag(<a href="#repeatable_string_flag-name">name</a>, <a href="#repeatable_string_flag-scope">scope</a>)
 </pre>
 
-A string-typed build setting that can be set on the command line. Multiple settings do not overwrite each other; they are concatenated into a list
-
+A build setting that accepts one or more string-typed settings on the command line, with the values concatenated into a single string list; for example, `--//my/setting=foo` `--//my/setting=bar` will be parsed as `["foo", "bar"]`. Contrast with `string_list_flag`
 **ATTRIBUTES**
 
 
@@ -116,7 +115,7 @@ A string-typed build setting that can be set on the command line. Multiple setti
 
 
 <a id="string_flag"></a>
-
+`
 ## string_flag
 
 <pre>
@@ -148,8 +147,7 @@ load("@bazel_skylib//rules:common_settings.bzl", "string_list_flag")
 string_list_flag(<a href="#string_list_flag-name">name</a>, <a href="#string_list_flag-scope">scope</a>)
 </pre>
 
-A string list-typed build setting that can be set on the command line
-
+A string list-typed build setting which expects its value on the command line to be given in comma-separated format; for example, `--//my/setting=foo,bar` will be parsed as `["foo", "bar"]`. Contrast with `repeatable_string_flag`.
 **ATTRIBUTES**
 
 

--- a/rules/common_settings.bzl
+++ b/rules/common_settings.bzl
@@ -99,7 +99,7 @@ bool_setting = rule(
     implementation = _impl,
     build_setting = config.bool(),
     attrs = {
-	"scope": _SCOPE_ATTR,
+        "scope": _SCOPE_ATTR,
     },
     doc = "A bool-typed build setting that cannot be set on the command line",
 )
@@ -117,13 +117,13 @@ def _repeatable_string_flag_impl(ctx):
     return BuildSettingInfo(value = ctx.build_setting_value)
 
 repeatable_string_flag = rule(
-    implementation = _flag_impl,
+    implementation = _repeatable_string_flag_impl,
     build_setting = config.string_list(
         flag = True,
         repeatable = True,
     ),
     attrs = {
-	"scope": _SCOPE_ATTR,
+        "scope": _SCOPE_ATTR,
     },
     doc = "A string-typed build setting that can be set on the command line. Multiple settings do not overwrite each other; they are concatenated into a list",
 )

--- a/rules/common_settings.bzl
+++ b/rules/common_settings.bzl
@@ -123,6 +123,25 @@ string_list_flag = rule(
     doc = "A string list-typed build setting that can be set on the command line",
 )
 
+def _flag_impl(ctx):
+    return BuildSettingInfo(value = ctx.build_setting_value)
+
+repeatable_string_flag = rule(
+    implementation = _flag_impl,
+    build_setting = config.string_list(
+        flag = True,
+        repeatable = True,
+    ),
+    attrs = {
+        "scope": attr.string(
+            doc = "The scope indicates where a flag can propagate to",
+            default = "universal",
+        ),
+    },
+    doc = "A string-typed build setting that can be set on the command line. Multiple settings do not overwrite each other; they are concatenated into a list",
+
+)
+
 string_list_setting = rule(
     implementation = _impl,
     build_setting = config.string_list(),

--- a/rules/common_settings.bzl
+++ b/rules/common_settings.bzl
@@ -125,7 +125,7 @@ repeatable_string_flag = rule(
     attrs = {
         "scope": _SCOPE_ATTR,
     },
-    doc = "A string-typed build setting that can be set on the command line. Multiple settings do not overwrite each other; they are concatenated into a list",
+    doc = "A build setting that accepts one or more string-typed settings on the command line, with the values concatenated into a single string list; for example, `--//my/setting=foo` `--//my/setting=bar` will be parsed as `['foo', 'bar']`. Contrast with `string_list_flag`",
 )
 
 string_list_setting = rule(
@@ -134,7 +134,7 @@ string_list_setting = rule(
     attrs = {
         "scope": _SCOPE_ATTR,
     },
-    doc = "A string list-typed build setting that cannot be set on the command line",
+    doc = "A string list-typed build setting which expects its value on the command line to be given in comma-separated format; for example, `--//my/setting=foo,bar` will be parsed as `['foo', 'bar']`. Contrast with `repeatable_string_flag`",
 )
 
 def _no_at_str(label):

--- a/rules/common_settings.bzl
+++ b/rules/common_settings.bzl
@@ -36,6 +36,11 @@ _MAKE_VARIABLE_ATTR = attr.string(
           "attribute.",
 )
 
+_SCOPE_ATTR = attr.string(
+    doc = "The scope indicates where a flag can propagate to",
+    default = "universal",
+)
+
 def _is_valid_make_variable_char(c):
     # Restrict make variable names for consistency with predefined ones. There are no enforced
     # restrictions on make variable names, but when they contain e.g. spaces or braces, they
@@ -66,10 +71,7 @@ int_flag = rule(
     build_setting = config.int(flag = True),
     attrs = {
         "make_variable": _MAKE_VARIABLE_ATTR,
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+        "scope": _SCOPE_ATTR,
     },
     doc = "An int-typed build setting that can be set on the command line",
 )
@@ -79,10 +81,7 @@ int_setting = rule(
     build_setting = config.int(),
     attrs = {
         "make_variable": _MAKE_VARIABLE_ATTR,
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+        "scope": _SCOPE_ATTR,
     },
     doc = "An int-typed build setting that cannot be set on the command line",
 )
@@ -91,10 +90,7 @@ bool_flag = rule(
     implementation = _impl,
     build_setting = config.bool(flag = True),
     attrs = {
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+        "scope": _SCOPE_ATTR,
     },
     doc = "A bool-typed build setting that can be set on the command line",
 )
@@ -103,10 +99,7 @@ bool_setting = rule(
     implementation = _impl,
     build_setting = config.bool(),
     attrs = {
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+	"scope": _SCOPE_ATTR,
     },
     doc = "A bool-typed build setting that cannot be set on the command line",
 )
@@ -115,15 +108,12 @@ string_list_flag = rule(
     implementation = _impl,
     build_setting = config.string_list(flag = True),
     attrs = {
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+        "scope": _SCOPE_ATTR,
     },
     doc = "A string list-typed build setting that can be set on the command line",
 )
 
-def _flag_impl(ctx):
+def _repeatable_string_flag_impl(ctx):
     return BuildSettingInfo(value = ctx.build_setting_value)
 
 repeatable_string_flag = rule(
@@ -133,10 +123,7 @@ repeatable_string_flag = rule(
         repeatable = True,
     ),
     attrs = {
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+	"scope": _SCOPE_ATTR,
     },
     doc = "A string-typed build setting that can be set on the command line. Multiple settings do not overwrite each other; they are concatenated into a list",
 )
@@ -145,10 +132,7 @@ string_list_setting = rule(
     implementation = _impl,
     build_setting = config.string_list(),
     attrs = {
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+        "scope": _SCOPE_ATTR,
     },
     doc = "A string list-typed build setting that cannot be set on the command line",
 )
@@ -178,10 +162,7 @@ string_flag = rule(
             doc = "The list of allowed values for this setting. An error is raised if any other value is given.",
         ),
         "make_variable": _MAKE_VARIABLE_ATTR,
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+        "scope": _SCOPE_ATTR,
     },
     doc = "A string-typed build setting that can be set on the command line",
 )
@@ -194,10 +175,7 @@ string_setting = rule(
             doc = "The list of allowed values for this setting. An error is raised if any other value is given.",
         ),
         "make_variable": _MAKE_VARIABLE_ATTR,
-        "scope": attr.string(
-            doc = "The scope indicates where a flag can propagate to",
-            default = "universal",
-        ),
+        "scope": _SCOPE_ATTR,
     },
     doc = "A string-typed build setting that cannot be set on the command line",
 )

--- a/rules/common_settings.bzl
+++ b/rules/common_settings.bzl
@@ -139,7 +139,6 @@ repeatable_string_flag = rule(
         ),
     },
     doc = "A string-typed build setting that can be set on the command line. Multiple settings do not overwrite each other; they are concatenated into a list",
-
 )
 
 string_list_setting = rule(


### PR DESCRIPTION
New settings of this flag type do not override each other; they are concatenated into a list. --foo=bar --foo=baz -> [bar, baz]. This is the equivalent of a string typed native flag with allow_multiple.