### PR TITLE
rules/private:is_windows should have empty applicable_licenses

### DIFF
--- a/rules/private/BUILD
+++ b/rules/private/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])
 
 is_windows(
     name = "is_windows",
+    applicable_licenses = [],  # no output artifacts
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Since the rule does not produce any output artifacts. Setting applicable_licenses to empty removes a dep edge from all users of copy_file to skylib's license, which makes a measurable difference for our monorepo.

Originally authored by @fdinoff.