### PR TITLE
Mark `bzl_library` as providing `StarlarkLibraryInfo`

### DIFF
--- a/rules/private/bzl_library.bzl
+++ b/rules/private/bzl_library.bzl
@@ -58,6 +58,7 @@ bzl_library = rule(
 Starlark files listed in `srcs`.""",
         ),
     },
+    provides = [StarlarkLibraryInfo],
     doc = """Creates a logical collection of Starlark .bzl and .scl files.
 
 Example:


### PR DESCRIPTION
Work towards https://github.com/bazelbuild/bazel/issues/18599, but useful even without it as it allows custom aspects to collect bzl files to generate docs for.