### PR TITLE
Replace ctx.files.srcs with ctx.attr.srcs in run_binary

### DIFF
--- a/rules/run_binary.bzl
+++ b/rules/run_binary.bzl
@@ -41,9 +41,12 @@ def _run_binary_impl(ctx):
         k: ctx.expand_location(v, tool_as_list)
         for k, v in ctx.attr.env.items()
     }
+    inputs = [
+        src[DefaultInfo].files for src in ctx.attr.srcs
+    ]
     ctx.actions.run(
         outputs = ctx.outputs.outs,
-        inputs = ctx.files.srcs,
+        inputs = depset(transitive = inputs),
         tools = [ctx.executable.tool],
         executable = ctx.executable.tool,
         arguments = args,

--- a/rules/run_binary.bzl
+++ b/rules/run_binary.bzl
@@ -42,7 +42,8 @@ def _run_binary_impl(ctx):
         for k, v in ctx.attr.env.items()
     }
     inputs = [
-        src[DefaultInfo].files for src in ctx.attr.srcs
+        src[DefaultInfo].files
+        for src in ctx.attr.srcs
     ]
     ctx.actions.run(
         outputs = ctx.outputs.outs,


### PR DESCRIPTION
The `ctx.files.srcs` maybe memory heavy in case of many input sources as it flattens depset, see https://github.com/bazelbuild/bazel/pull/28753

In below reproduction that creates 100k actions, each having 10k inputs this fix allows the `used-heap-size-after-gc` to drop from 8GB to 300M.

<details>

<summary>Repo</summary>

### MODULE.bazel
```python
bazel_dep(name = "bazel_skylib", version = "1.9.0")
```

### myecho
```bash
echo "$1" > $2
```

### BUILD.bazel

```python
load("@bazel_skylib//rules:run_binary.bzl", "run_binary")

GENERATED_INPUTS=10000
ACTIONS = 100000

[
    run_binary(
        name="gen_file_" + str(idx),
        args = ["content_gen" + str(idx), "$(location :file_" + str(idx) + ")"],
        tool = ":myecho",
        outs = ["file_" + str(idx)],
    )
    for idx in range(GENERATED_INPUTS)
]

filegroup(
     name="genfiles",
     srcs = ["gen_file_" + str(idx) for idx in range(GENERATED_INPUTS)]
)

[
    run_binary(
        name = "action_" + str(idx),
        args = ["content_action" + str(idx), "$(location :out_" + str(idx) + ")"],
        tool = ":myecho",
        outs = ["out_" + str(idx)],
        srcs = [":genfiles"],
    )
    for idx in range(ACTIONS)
]

run_binary(
    name = "result",
    args = ["content_result", "$(location :final_out)"],
    tool = ":myecho",
    srcs = [":out_" + str(idx) for idx in range(ACTIONS)],
    outs = ["final_out"],
)
```

</details>

Before:

```bash
$ USE_BAZEL_VERSION=9.0.0 bazelisk --host_jvm_args=-Xmx64g build :result --nobuild
...
$ USE_BAZEL_VERSION=9.0.0 bazelisk --host_jvm_args=-Xmx64g info used-heap-size-after-gc
8461MB
```

After:

```bash
$ USE_BAZEL_VERSION=9.0.0 bazelisk --host_jvm_args=-Xmx64g info used-heap-size-after-gc
305MB
```