### PR TITLE
Add local_path_override for skylib from gazelle

### DIFF
--- a/gazelle/MODULE.bazel
+++ b/gazelle/MODULE.bazel
@@ -7,6 +7,11 @@ module(
 
 # Keep in sync with @bazel_skylib//:MODULE.bazel and @bazel_skylib//:version.bzl
 bazel_dep(name = "bazel_skylib", version = "1.9.1")
+local_path_override(
+    module_name = "bazel_skylib",
+    path = "..",
+)
+
 bazel_dep(name = "rules_license", version = "0.0.7")
 bazel_dep(name = "gazelle", version = "0.41.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "rules_go", version = "0.59.0", repo_name = "io_bazel_rules_go")


### PR DESCRIPTION
Otherwise this fails when you're testing the gazelle module locally
since it relies on versions that aren't released. This doesn't apply for
downstream consumers.
