### PR TITLE
Remove private visibility on "always_true" conditions

### DIFF
--- a/lib/BUILD
+++ b/lib/BUILD
@@ -124,19 +124,16 @@ bzl_library(
 bool_setting(
     name = "bool",
     build_setting_default = False,
-    visibility = ["//visibility:private"],
 )
 
 config_setting(
     name = "bool_on",
     flag_values = {":bool": "true"},
-    visibility = ["//visibility:private"],
 )
 
 config_setting(
     name = "bool_off",
     flag_values = {":bool": "false"},
-    visibility = ["//visibility:private"],
 )
 
 selects.config_setting_group(


### PR DESCRIPTION
This fixes visibility errors from `//tests:match_always_true_rule` and users who want full access to the selects API.

Issue discovered at https://bazelbuild.slack.com/archives/CA31HN1T3/p1782435671535049.

CI didn't catch this because CI sets `--incompatible_enforce_config_setting_visibility`:  https://github.com/bazelbuild/bazel/issues/12933. That's bizarre because that flag should make visibility *more* restrictive, not *less*. But that's what's going on:

## Repro:
```sh
$ USE_BAZEL_VERSION=8.7.0 bazelisk cquery //tests:match_any_always_true_rule
ERROR: bazel/bazel-skylib/tests/BUILD:47:19: in boolean_attr_rule rule //tests:match_any_always_true_rule: Visibility error:
target '//lib:bool_off' is not visible from
target '//tests:match_any_always_true_rule'

$ USE_BAZEL_VERSION=8.7.0 bazelisk cquery //tests:match_any_always_true_rule  --incompatible_config_setting_private_default_visibility
INFO: Analyzed target //tests:match_any_always_true_rule (8 packages loaded, 15 targets configured).
INFO: Found 1 target...
//tests:match_any_always_true_rule (c5c1711)
```

This is motivated by release 1.9.1 failing: https://github.com/bazelbuild/bazel-skylib/actions/runs/25128976486.