### PR TITLE
Remove macos from presubmit.yml because macos_arm64 is present

### DIFF
--- a/.bcr/gazelle/presubmit.yml
+++ b/.bcr/gazelle/presubmit.yml
@@ -2,7 +2,6 @@ matrix:
   platform:
   - rockylinux8
   - debian10
-  - macos
   - macos_arm64
   - ubuntu2204
   - ubuntu2404

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,6 @@ matrix:
   platform:
   - rockylinux8
   - debian10
-  - macos
   - macos_arm64
   - ubuntu2204
   - ubuntu2404


### PR DESCRIPTION
As suggested by @ted-xie in review of https://github.com/bazelbuild/bazel-central-registry/pull/9736